### PR TITLE
Fix: test case in torch_judge

### DIFF
--- a/torch_judge/tasks/rope.py
+++ b/torch_judge/tasks/rope.py
@@ -11,7 +11,7 @@ TASK = {
             "code": """
 import torch
 x = torch.randn(2, 4, 8, 16)  # (batch, heads, seq, head_dim)
-pos = torch.arange(4).unsqueeze(0).expand(2, -1)  # (batch, seq)
+pos = torch.arange(8).unsqueeze(0).expand(2, -1)  # (batch, seq)
 out = {fn}(x, pos)
 assert out.shape == x.shape, f'Shape mismatch: {out.shape}'
 """,


### PR DESCRIPTION
# Problem
- In `torch_judge/tasks/rope.py`, the first test case, the `seq` of `x` does not match the `seq` generated for `pos`.

# Change
- Changed `arange(4)` to `arange(8)`.