### PR TITLE
Add ML and RLHF practice problems

### DIFF
--- a/solutions/25_kmeans_solution.ipynb
+++ b/solutions/25_kmeans_solution.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: K-Means Clustering"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def kmeans(x: torch.Tensor, num_clusters: int, num_iters: int = 10) -> tuple[torch.Tensor, torch.Tensor]:\n",
+    "    centroids = x[:num_clusters].clone()\n",
+    "\n",
+    "    for _ in range(num_iters):\n",
+    "        distances = torch.cdist(x, centroids)\n",
+    "        assignments = distances.argmin(dim=1)\n",
+    "\n",
+    "        new_centroids = centroids.clone()\n",
+    "        for cluster_idx in range(num_clusters):\n",
+    "            mask = assignments == cluster_idx\n",
+    "            if mask.any():\n",
+    "                new_centroids[cluster_idx] = x[mask].mean(dim=0)\n",
+    "\n",
+    "        centroids = new_centroids\n",
+    "\n",
+    "    distances = torch.cdist(x, centroids)\n",
+    "    assignments = distances.argmin(dim=1)\n",
+    "    return centroids, assignments\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "x = torch.tensor([\n",
+    "    [0.0, 0.0],\n",
+    "    [5.0, 5.0],\n",
+    "    [0.0, 1.0],\n",
+    "    [6.0, 5.0],\n",
+    "])\n",
+    "centroids, assignments = kmeans(x, num_clusters=2, num_iters=5)\n",
+    "print(\"Centroids:\\n\", centroids)\n",
+    "print(\"Assignments:\", assignments)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/26_knn_solution.ipynb
+++ b/solutions/26_knn_solution.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟢 Solution: K-Nearest Neighbors Classification"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def knn_predict(x_train: torch.Tensor, y_train: torch.Tensor, x_query: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    distances = torch.cdist(x_query, x_train)\n",
+    "    nearest = distances.topk(k, largest=False, dim=-1).indices\n",
+    "    neighbor_labels = y_train[nearest]\n",
+    "    num_classes = int(y_train.max().item()) + 1\n",
+    "    preds = []\n",
+    "    for labels in neighbor_labels:\n",
+    "        preds.append(torch.bincount(labels, minlength=num_classes).argmax())\n",
+    "    return torch.stack(preds)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "x_train = torch.tensor([[0.0, 0.0], [0.0, 1.0], [3.0, 3.0]])\n",
+    "y_train = torch.tensor([0, 0, 1])\n",
+    "x_query = torch.tensor([[0.1, 0.2], [2.8, 3.1]])\n",
+    "print(knn_predict(x_train, y_train, x_query, k=1))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/27_mlp_backward_solution.ipynb
+++ b/solutions/27_mlp_backward_solution.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: Hand-Written Backward for a 2-Layer MLP"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def mlp_backward(x, w1, b1, w2, b2, target) -> dict[str, torch.Tensor]:\n",
+    "    z1 = x @ w1.T + b1\n",
+    "    h = torch.relu(z1)\n",
+    "    y = h @ w2.T + b2\n",
+    "\n",
+    "    grad_y = 2.0 * (y - target) / y.numel()\n",
+    "    grad_w2 = grad_y.T @ h\n",
+    "    grad_b2 = grad_y.sum(dim=0)\n",
+    "\n",
+    "    grad_h = grad_y @ w2\n",
+    "    grad_z1 = grad_h * (z1 > 0).to(z1.dtype)\n",
+    "    grad_w1 = grad_z1.T @ x\n",
+    "    grad_b1 = grad_z1.sum(dim=0)\n",
+    "\n",
+    "    return {\n",
+    "        \"w1\": grad_w1,\n",
+    "        \"b1\": grad_b1,\n",
+    "        \"w2\": grad_w2,\n",
+    "        \"b2\": grad_b2,\n",
+    "    }\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "x = torch.randn(2, 3)\n",
+    "w1 = torch.randn(4, 3)\n",
+    "b1 = torch.randn(4)\n",
+    "w2 = torch.randn(2, 4)\n",
+    "b2 = torch.randn(2)\n",
+    "target = torch.randn(2, 2)\n",
+    "grads = mlp_backward(x, w1, b1, w2, b2, target)\n",
+    "print(grads.keys())\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/28_greedy_sampling_solution.ipynb
+++ b/solutions/28_greedy_sampling_solution.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟢 Solution: Greedy Search Decoding"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def greedy_decode(logits: torch.Tensor) -> torch.Tensor:\n",
+    "    return logits.argmax(dim=-1)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "logits = torch.tensor([[0.0, 3.0, 1.0], [2.0, 1.0, 2.5]])\n",
+    "print(greedy_decode(logits))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/29_beam_search_solution.ipynb
+++ b/solutions/29_beam_search_solution.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: Beam Search Decoding"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def beam_search_decode(log_probs: torch.Tensor, beam_width: int) -> tuple[torch.Tensor, float]:\n",
+    "    beams = [([], 0.0)]\n",
+    "    seq_len, vocab_size = log_probs.shape\n",
+    "\n",
+    "    for t in range(seq_len):\n",
+    "        candidates = []\n",
+    "        for sequence, score in beams:\n",
+    "            for token in range(vocab_size):\n",
+    "                candidates.append((sequence + [token], score + float(log_probs[t, token].item())))\n",
+    "        candidates.sort(key=lambda item: item[1], reverse=True)\n",
+    "        beams = candidates[:beam_width]\n",
+    "\n",
+    "    best_sequence, best_score = beams[0]\n",
+    "    return torch.tensor(best_sequence, dtype=torch.long), best_score\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "log_probs = torch.log(torch.tensor([\n",
+    "    [0.6, 0.3, 0.1],\n",
+    "    [0.2, 0.5, 0.3],\n",
+    "], dtype=torch.float32))\n",
+    "print(beam_search_decode(log_probs, beam_width=2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/30_temperature_sampling_solution.ipynb
+++ b/solutions/30_temperature_sampling_solution.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: Temperature Sampling"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def temperature_sample(logits: torch.Tensor, temperature: float) -> torch.Tensor:\n",
+    "    if temperature <= 0:\n",
+    "        raise ValueError(\"temperature must be positive\")\n",
+    "\n",
+    "    squeeze = logits.dim() == 1\n",
+    "    if squeeze:\n",
+    "        logits = logits.unsqueeze(0)\n",
+    "\n",
+    "    probs = torch.softmax(logits / temperature, dim=-1)\n",
+    "    samples = torch.multinomial(probs, num_samples=1).squeeze(-1)\n",
+    "    return samples.squeeze(0) if squeeze else samples\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])\n",
+    "print(temperature_sample(logits, temperature=0.7))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/31_top_k_sampling_solution.ipynb
+++ b/solutions/31_top_k_sampling_solution.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: Top-k Sampling"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def top_k_sample(logits: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    squeeze = logits.dim() == 1\n",
+    "    if squeeze:\n",
+    "        logits = logits.unsqueeze(0)\n",
+    "\n",
+    "    k = min(k, logits.shape[-1])\n",
+    "    top_values, top_indices = torch.topk(logits, k=k, dim=-1)\n",
+    "    masked = torch.full_like(logits, float(\"-inf\"))\n",
+    "    masked.scatter_(-1, top_indices, top_values)\n",
+    "    probs = torch.softmax(masked, dim=-1)\n",
+    "    samples = torch.multinomial(probs, num_samples=1).squeeze(-1)\n",
+    "    return samples.squeeze(0) if squeeze else samples\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[5.0, 4.0, 1.0, -2.0]])\n",
+    "print(top_k_sample(logits, k=2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/32_top_p_sampling_solution.ipynb
+++ b/solutions/32_top_p_sampling_solution.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: Top-p Sampling"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def top_p_sample(logits: torch.Tensor, p: float) -> torch.Tensor:\n",
+    "    squeeze = logits.dim() == 1\n",
+    "    if squeeze:\n",
+    "        logits = logits.unsqueeze(0)\n",
+    "\n",
+    "    probs = torch.softmax(logits, dim=-1)\n",
+    "    outputs = []\n",
+    "    for row in probs:\n",
+    "        sorted_probs, sorted_indices = torch.sort(row, descending=True)\n",
+    "        cumulative = sorted_probs.cumsum(dim=0)\n",
+    "        keep = cumulative <= p\n",
+    "        keep[0] = True\n",
+    "\n",
+    "        first_exceed = torch.nonzero(cumulative > p, as_tuple=False)\n",
+    "        if first_exceed.numel() > 0:\n",
+    "            keep[first_exceed[0, 0]] = True\n",
+    "\n",
+    "        filtered = torch.zeros_like(row)\n",
+    "        filtered[sorted_indices[keep]] = row[sorted_indices[keep]]\n",
+    "        filtered = filtered / filtered.sum()\n",
+    "        outputs.append(torch.multinomial(filtered, num_samples=1).squeeze(0))\n",
+    "\n",
+    "    outputs = torch.stack(outputs)\n",
+    "    return outputs.squeeze(0) if squeeze else outputs\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[4.0, 3.5, 1.0, -2.0]])\n",
+    "print(top_p_sample(logits, p=0.8))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/33_ppo_loss_solution.ipynb
+++ b/solutions/33_ppo_loss_solution.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: PPO Clipped Policy Loss"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps: float) -> torch.Tensor:\n",
+    "    ratio = torch.exp(new_log_probs - old_log_probs)\n",
+    "    unclipped = ratio * advantages\n",
+    "    clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * advantages\n",
+    "    return -torch.minimum(unclipped, clipped).mean()\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "old_log_probs = torch.log(torch.tensor([0.2, 0.5, 0.3]))\n",
+    "new_log_probs = torch.log(torch.tensor([0.25, 0.45, 0.3]))\n",
+    "advantages = torch.tensor([1.0, -0.5, 2.0])\n",
+    "print(ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps=0.2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/34_dpo_loss_solution.ipynb
+++ b/solutions/34_dpo_loss_solution.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: DPO Loss"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch\n",
+    "import torch.nn.functional as F"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta: float) -> torch.Tensor:\n",
+    "    logits = beta * ((policy_chosen - policy_rejected) - (ref_chosen - ref_rejected))\n",
+    "    return -F.logsigmoid(logits).mean()\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "policy_chosen = torch.tensor([-0.2, -0.4])\n",
+    "policy_rejected = torch.tensor([-1.0, -0.5])\n",
+    "ref_chosen = torch.tensor([-0.3, -0.4])\n",
+    "ref_rejected = torch.tensor([-0.7, -0.4])\n",
+    "print(dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta=0.5))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/35_grpo_loss_solution.ipynb
+++ b/solutions/35_grpo_loss_solution.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: GRPO Loss"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps: float) -> torch.Tensor:\n",
+    "    advantages = torch.zeros_like(rewards)\n",
+    "    for gid in torch.unique(group_ids):\n",
+    "        mask = group_ids == gid\n",
+    "        group_rewards = rewards[mask]\n",
+    "        advantages[mask] = (group_rewards - group_rewards.mean()) / (group_rewards.std(unbiased=False) + 1e-8)\n",
+    "\n",
+    "    ratio = torch.exp(new_log_probs - old_log_probs)\n",
+    "    unclipped = ratio * advantages\n",
+    "    clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * advantages\n",
+    "    return -torch.minimum(unclipped, clipped).mean()\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Verify\n",
+    "old_log_probs = torch.log(torch.tensor([0.3, 0.4, 0.2, 0.5]))\n",
+    "new_log_probs = torch.log(torch.tensor([0.33, 0.36, 0.25, 0.45]))\n",
+    "rewards = torch.tensor([1.0, 3.0, 2.0, 6.0])\n",
+    "group_ids = torch.tensor([0, 0, 1, 1])\n",
+    "print(grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/25_kmeans.ipynb
+++ b/templates/25_kmeans.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: K-Means Clustering\n",
+    "\n",
+    "Implement **K-Means clustering** from scratch using PyTorch tensors.\n",
+    "\n",
+    "Use a deterministic initialization rule: take the **first `num_clusters` points** as the initial centroids.\n",
+    "\n",
+    "Then repeat:\n",
+    "1. Assign each point to its nearest centroid.\n",
+    "2. Recompute each centroid as the mean of its assigned points.\n",
+    "3. If a cluster becomes empty, keep its previous centroid.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def kmeans(x: torch.Tensor, num_clusters: int, num_iters: int = 10) -> tuple[torch.Tensor, torch.Tensor]:\n",
+    "    # x: (num_points, dim)\n",
+    "    # returns: (centroids, assignments)\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Use only PyTorch tensor ops\n",
+    "- Do not call external clustering libraries\n",
+    "- `assignments` should contain the index of the nearest centroid for each point\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "x = tensor([[0., 0.],\n",
+    "            [5., 5.],\n",
+    "            [0., 1.],\n",
+    "            [6., 5.]])\n",
+    "\n",
+    "centroids, assignments = kmeans(x, num_clusters=2, num_iters=5)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def kmeans(x: torch.Tensor, num_clusters: int, num_iters: int = 10) -> tuple[torch.Tensor, torch.Tensor]:\n",
+    "    # x: (num_points, dim)\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "x = torch.tensor([\n",
+    "    [0.0, 0.0],\n",
+    "    [5.0, 5.0],\n",
+    "    [0.0, 1.0],\n",
+    "    [6.0, 5.0],\n",
+    "])\n",
+    "centroids, assignments = kmeans(x, num_clusters=2, num_iters=5)\n",
+    "print(\"Centroids:\\n\", centroids)\n",
+    "print(\"Assignments:\", assignments)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"kmeans\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/26_knn.ipynb
+++ b/templates/26_knn.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟢 Easy: K-Nearest Neighbors Classification\n",
+    "\n",
+    "Implement **KNN classification** from scratch.\n",
+    "\n",
+    "For each query point:\n",
+    "1. Compute distances to all training points.\n",
+    "2. Select the `k` nearest labels.\n",
+    "3. Return the majority label.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def knn_predict(x_train: torch.Tensor, y_train: torch.Tensor, x_query: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Use PyTorch tensor operations\n",
+    "- Return one predicted label per query point\n",
+    "- Break ties by choosing the smaller label\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "pred = knn_predict(x_train, y_train, x_query, k=3)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def knn_predict(x_train: torch.Tensor, y_train: torch.Tensor, x_query: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "x_train = torch.tensor([[0.0, 0.0], [0.0, 1.0], [3.0, 3.0]])\n",
+    "y_train = torch.tensor([0, 0, 1])\n",
+    "x_query = torch.tensor([[0.1, 0.2], [2.8, 3.1]])\n",
+    "print(knn_predict(x_train, y_train, x_query, k=1))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"knn\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/27_mlp_backward.ipynb
+++ b/templates/27_mlp_backward.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: Hand-Written Backward for a 2-Layer MLP\n",
+    "\n",
+    "Implement the **manual backward pass** for a 2-layer MLP with ReLU activation and MSE loss.\n",
+    "\n",
+    "Forward definition:\n",
+    "- `z1 = x @ w1.T + b1`\n",
+    "- `h = relu(z1)`\n",
+    "- `y = h @ w2.T + b2`\n",
+    "- `loss = mean((y - target)^2)`\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def mlp_backward(x, w1, b1, w2, b2, target) -> dict[str, torch.Tensor]:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Do not call `backward()` inside your implementation\n",
+    "- Return gradients for `w1`, `b1`, `w2`, and `b2`\n",
+    "- Match PyTorch autograd numerically\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "grads = mlp_backward(x, w1, b1, w2, b2, target)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def mlp_backward(x, w1, b1, w2, b2, target) -> dict[str, torch.Tensor]:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "x = torch.randn(2, 3)\n",
+    "w1 = torch.randn(4, 3)\n",
+    "b1 = torch.randn(4)\n",
+    "w2 = torch.randn(2, 4)\n",
+    "b2 = torch.randn(2)\n",
+    "target = torch.randn(2, 2)\n",
+    "grads = mlp_backward(x, w1, b1, w2, b2, target)\n",
+    "print(grads.keys())\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"mlp_backward\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/28_greedy_sampling.ipynb
+++ b/templates/28_greedy_sampling.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟢 Easy: Greedy Search Decoding\n",
+    "\n",
+    "Implement **greedy decoding** for logits.\n",
+    "\n",
+    "Greedy decoding simply picks the token with the largest logit at each position.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def greedy_decode(logits: torch.Tensor) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- The vocabulary dimension is the last dimension\n",
+    "- Return argmax indices along the last dimension\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "token_ids = greedy_decode(logits)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def greedy_decode(logits: torch.Tensor) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "logits = torch.tensor([[0.0, 3.0, 1.0], [2.0, 1.0, 2.5]])\n",
+    "print(greedy_decode(logits))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"greedy_sampling\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/29_beam_search.ipynb
+++ b/templates/29_beam_search.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: Beam Search Decoding\n",
+    "\n",
+    "Implement a simplified **beam search decoder** over a matrix of log-probabilities.\n",
+    "\n",
+    "Input shape: `(seq_len, vocab_size)`.\n",
+    "At each timestep, expand all current beams with every token, accumulate log-probabilities, and keep the top `beam_width` sequences.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def beam_search_decode(log_probs: torch.Tensor, beam_width: int) -> tuple[torch.Tensor, float]:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Return the best sequence and its total log-probability\n",
+    "- Sequence length must equal `seq_len`\n",
+    "- Use additive scores in log space\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "sequence, score = beam_search_decode(log_probs, beam_width=3)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def beam_search_decode(log_probs: torch.Tensor, beam_width: int) -> tuple[torch.Tensor, float]:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "log_probs = torch.log(torch.tensor([\n",
+    "    [0.6, 0.3, 0.1],\n",
+    "    [0.2, 0.5, 0.3],\n",
+    "], dtype=torch.float32))\n",
+    "print(beam_search_decode(log_probs, beam_width=2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"beam_search\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/30_temperature_sampling.ipynb
+++ b/templates/30_temperature_sampling.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: Temperature Sampling\n",
+    "\n",
+    "Implement **temperature sampling** from logits.\n",
+    "\n",
+    "Scale the logits by dividing by `temperature`, apply softmax, then sample a token.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def temperature_sample(logits: torch.Tensor, temperature: float) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Support both 1-D and batched logits\n",
+    "- Sample one token per row\n",
+    "- `temperature` must be positive\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "token_ids = temperature_sample(logits, temperature=0.8)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def temperature_sample(logits: torch.Tensor, temperature: float) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])\n",
+    "print(temperature_sample(logits, temperature=0.7))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"temperature_sampling\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/31_top_k_sampling.ipynb
+++ b/templates/31_top_k_sampling.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: Top-k Sampling\n",
+    "\n",
+    "Implement **top-k sampling** for logits.\n",
+    "\n",
+    "Keep only the top `k` logits, mask the rest out, and sample from the remaining distribution.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def top_k_sample(logits: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Support both 1-D and batched logits\n",
+    "- Return one sampled token per row\n",
+    "- `k=1` should behave like greedy decoding\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "token_ids = top_k_sample(logits, k=10)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def top_k_sample(logits: torch.Tensor, k: int) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[5.0, 4.0, 1.0, -2.0]])\n",
+    "print(top_k_sample(logits, k=2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"top_k_sampling\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/32_top_p_sampling.ipynb
+++ b/templates/32_top_p_sampling.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: Top-p Sampling\n",
+    "\n",
+    "Implement **top-p (nucleus) sampling**.\n",
+    "\n",
+    "Sort tokens by probability, keep the smallest prefix whose cumulative probability reaches `p`, renormalize, then sample from that nucleus.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def top_p_sample(logits: torch.Tensor, p: float) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Support both 1-D and batched logits\n",
+    "- Always keep at least one token\n",
+    "- Sample one token per row\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "token_ids = top_p_sample(logits, p=0.9)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def top_p_sample(logits: torch.Tensor, p: float) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "torch.manual_seed(0)\n",
+    "logits = torch.tensor([[4.0, 3.5, 1.0, -2.0]])\n",
+    "print(top_p_sample(logits, p=0.8))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"top_p_sampling\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/33_ppo_loss.ipynb
+++ b/templates/33_ppo_loss.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: PPO Clipped Policy Loss\n",
+    "\n",
+    "Implement the **clipped PPO policy loss**.\n",
+    "\n",
+    "Use:\n",
+    "- `ratio = exp(new_log_probs - old_log_probs)`\n",
+    "- `unclipped = ratio * advantages`\n",
+    "- `clipped = clamp(ratio, 1-eps, 1+eps) * advantages`\n",
+    "- `loss = -mean(min(unclipped, clipped))`\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps: float) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "loss = ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps=0.2)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps: float) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "old_log_probs = torch.log(torch.tensor([0.2, 0.5, 0.3]))\n",
+    "new_log_probs = torch.log(torch.tensor([0.25, 0.45, 0.3]))\n",
+    "advantages = torch.tensor([1.0, -0.5, 2.0])\n",
+    "print(ppo_clipped_loss(old_log_probs, new_log_probs, advantages, clip_eps=0.2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"ppo_loss\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/34_dpo_loss.ipynb
+++ b/templates/34_dpo_loss.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: DPO Loss\n",
+    "\n",
+    "Implement the **Direct Preference Optimization (DPO)** loss.\n",
+    "\n",
+    "Use the policy preference gap relative to the reference model:\n",
+    "`beta * ((pi_chosen - pi_rejected) - (ref_chosen - ref_rejected))`\n",
+    "\n",
+    "Then apply `-logsigmoid(...)` and average across the batch.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta: float) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "loss = dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta=0.1)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch\n",
+    "import torch.nn.functional as F"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta: float) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "policy_chosen = torch.tensor([-0.2, -0.4])\n",
+    "policy_rejected = torch.tensor([-1.0, -0.5])\n",
+    "ref_chosen = torch.tensor([-0.3, -0.4])\n",
+    "ref_rejected = torch.tensor([-0.7, -0.4])\n",
+    "print(dpo_loss(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta=0.5))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"dpo_loss\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/35_grpo_loss.ipynb
+++ b/templates/35_grpo_loss.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: GRPO Loss\n",
+    "\n",
+    "Implement a simplified **GRPO loss**.\n",
+    "\n",
+    "First normalize rewards within each group:\n",
+    "`adv = (reward - mean(group)) / (std(group) + 1e-8)`\n",
+    "\n",
+    "Then plug those group-relative advantages into the clipped PPO objective.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps: float) -> torch.Tensor:\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "loss = grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2)\n",
+    "```"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps: float) -> torch.Tensor:\n",
+    "    pass  # Replace this\n",
+    ""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "old_log_probs = torch.log(torch.tensor([0.3, 0.4, 0.2, 0.5]))\n",
+    "new_log_probs = torch.log(torch.tensor([0.33, 0.36, 0.25, 0.45]))\n",
+    "rewards = torch.tensor([1.0, 3.0, 2.0, 6.0])\n",
+    "group_ids = torch.tensor([0, 0, 1, 1])\n",
+    "print(grpo_loss(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2))\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"grpo_loss\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/torch_judge/tasks/beam_search.py
+++ b/torch_judge/tasks/beam_search.py
@@ -1,0 +1,68 @@
+"""Beam search decoding task."""
+
+TASK = {
+    "title": "Beam Search Decoding",
+    "difficulty": "Hard",
+    "function_name": "beam_search_decode",
+    "hint": (
+        "Keep a list of the top beam_width partial sequences. At each timestep, expand "
+        "every beam with every token, add the current log-probability to the running "
+        "score, then keep only the best beam_width candidates."
+    ),
+    "tests": [
+        {
+            "name": "Output types",
+            "code": """
+import torch
+log_probs = torch.log(torch.tensor([
+    [0.6, 0.3, 0.1],
+    [0.2, 0.5, 0.3],
+], dtype=torch.float32))
+sequence, score = {fn}(log_probs, beam_width=2)
+assert isinstance(sequence, torch.Tensor), f'Sequence should be a tensor, got {type(sequence)}'
+assert sequence.shape == (2,), f'Sequence shape mismatch: {sequence.shape}'
+assert sequence.dtype in (torch.int32, torch.int64), f'Sequence should be integer typed, got {sequence.dtype}'
+assert isinstance(score, float), f'Score should be a Python float, got {type(score)}'
+""",
+        },
+        {
+            "name": "Matches exhaustive search on tiny example",
+            "code": """
+import itertools
+import torch
+log_probs = torch.log(torch.tensor([
+    [0.50, 0.30, 0.20],
+    [0.10, 0.70, 0.20],
+    [0.60, 0.25, 0.15],
+], dtype=torch.float32))
+sequence, score = {fn}(log_probs, beam_width=2)
+best_seq = None
+best_score = None
+for seq in itertools.product(range(3), repeat=3):
+    seq_score = sum(log_probs[t, token].item() for t, token in enumerate(seq))
+    if best_score is None or seq_score > best_score:
+        best_seq = seq
+        best_score = seq_score
+expected_sequence = torch.tensor(best_seq)
+assert torch.equal(sequence, expected_sequence), f'Wrong sequence: {sequence} vs {expected_sequence}'
+assert abs(score - best_score) < 1e-6, f'Wrong score: {score} vs {best_score}'
+""",
+        },
+        {
+            "name": "Beam width 1 equals greedy",
+            "code": """
+import torch
+log_probs = torch.log(torch.tensor([
+    [0.1, 0.8, 0.1],
+    [0.7, 0.1, 0.2],
+    [0.2, 0.3, 0.5],
+], dtype=torch.float32))
+sequence, score = {fn}(log_probs, beam_width=1)
+expected = torch.tensor([1, 0, 2])
+expected_score = log_probs[0, 1].item() + log_probs[1, 0].item() + log_probs[2, 2].item()
+assert torch.equal(sequence, expected), f'Beam width 1 should be greedy: {sequence} vs {expected}'
+assert abs(score - expected_score) < 1e-6, 'Score mismatch for beam width 1'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/dpo_loss.py
+++ b/torch_judge/tasks/dpo_loss.py
@@ -1,0 +1,71 @@
+"""DPO loss task."""
+
+TASK = {
+    "title": "DPO Loss",
+    "difficulty": "Hard",
+    "function_name": "dpo_loss",
+    "hint": (
+        "DPO compares the policy preference gap against the reference preference gap. "
+        "Compute logits = beta * ((pi_chosen - pi_rejected) - (ref_chosen - ref_rejected)), "
+        "then return -logsigmoid(logits).mean()."
+    ),
+    "tests": [
+        {
+            "name": "Matches reference formula",
+            "code": """
+import torch
+import torch.nn.functional as F
+policy_chosen = torch.tensor([-0.2, -0.4, -0.1])
+policy_rejected = torch.tensor([-1.0, -0.5, -0.8])
+ref_chosen = torch.tensor([-0.3, -0.4, -0.2])
+ref_rejected = torch.tensor([-0.7, -0.4, -0.6])
+loss = {fn}(policy_chosen, policy_rejected, ref_chosen, ref_rejected, beta=0.5)
+logits = 0.5 * ((policy_chosen - policy_rejected) - (ref_chosen - ref_rejected))
+expected = -F.logsigmoid(logits).mean()
+assert torch.allclose(loss, expected, atol=1e-6), f'Loss mismatch: {loss} vs {expected}'
+""",
+        },
+        {
+            "name": "Stronger policy preference lowers the loss",
+            "code": """
+import torch
+weak = {fn}(
+    torch.tensor([-0.5]),
+    torch.tensor([-0.7]),
+    torch.tensor([-0.4]),
+    torch.tensor([-0.6]),
+    beta=1.0,
+)
+strong = {fn}(
+    torch.tensor([-0.1]),
+    torch.tensor([-1.2]),
+    torch.tensor([-0.4]),
+    torch.tensor([-0.6]),
+    beta=1.0,
+)
+assert strong < weak, f'Stronger preferred-vs-rejected gap should reduce loss: {strong} vs {weak}'
+""",
+        },
+        {
+            "name": "Larger beta sharpens the penalty",
+            "code": """
+import torch
+low_beta = {fn}(
+    torch.tensor([-0.3]),
+    torch.tensor([-0.4]),
+    torch.tensor([-0.3]),
+    torch.tensor([-0.2]),
+    beta=0.1,
+)
+high_beta = {fn}(
+    torch.tensor([-0.3]),
+    torch.tensor([-0.4]),
+    torch.tensor([-0.3]),
+    torch.tensor([-0.2]),
+    beta=2.0,
+)
+assert high_beta < low_beta, f'When the policy is better than reference, larger beta should reduce loss: {high_beta} vs {low_beta}'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/greedy_sampling.py
+++ b/torch_judge/tasks/greedy_sampling.py
@@ -1,0 +1,45 @@
+"""Greedy decoding task."""
+
+TASK = {
+    "title": "Greedy Search Decoding",
+    "difficulty": "Easy",
+    "function_name": "greedy_decode",
+    "hint": "Greedy decoding picks the token with the largest logit at each position. This is just argmax over the vocabulary dimension.",
+    "tests": [
+        {
+            "name": "1-D logits",
+            "code": """
+import torch
+logits = torch.tensor([0.1, 2.5, -1.0, 2.4])
+out = {fn}(logits)
+assert out.shape == (), f'Expected scalar output for 1-D logits, got {out.shape}'
+assert out.item() == 1, f'Expected token 1, got {out.item()}'
+""",
+        },
+        {
+            "name": "Batch decoding",
+            "code": """
+import torch
+logits = torch.tensor([
+    [0.0, 3.0, 1.0],
+    [2.0, 1.0, 2.5],
+    [-5.0, -1.0, -2.0],
+])
+out = {fn}(logits)
+expected = torch.tensor([1, 2, 1])
+assert torch.equal(out, expected), f'Wrong greedy predictions: {out} vs {expected}'
+""",
+        },
+        {
+            "name": "Matches torch.argmax",
+            "code": """
+import torch
+torch.manual_seed(0)
+logits = torch.randn(4, 7, 13)
+out = {fn}(logits)
+expected = logits.argmax(dim=-1)
+assert torch.equal(out, expected), 'greedy_decode should match argmax(dim=-1)'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/grpo_loss.py
+++ b/torch_judge/tasks/grpo_loss.py
@@ -1,0 +1,63 @@
+"""GRPO loss task."""
+
+TASK = {
+    "title": "GRPO Loss",
+    "difficulty": "Hard",
+    "function_name": "grpo_loss",
+    "hint": (
+        "First normalize rewards within each group to get group-relative advantages: "
+        "(r - mean(group)) / (std(group) + eps). Then reuse the PPO clipped objective "
+        "with ratio = exp(new_log_probs - old_log_probs)."
+    ),
+    "tests": [
+        {
+            "name": "Matches reference formula",
+            "code": """
+import torch
+old_log_probs = torch.log(torch.tensor([0.3, 0.4, 0.2, 0.5], dtype=torch.float32))
+new_log_probs = torch.log(torch.tensor([0.33, 0.36, 0.25, 0.45], dtype=torch.float32))
+rewards = torch.tensor([1.0, 3.0, 2.0, 6.0], dtype=torch.float32)
+group_ids = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+loss = {fn}(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2)
+
+advantages = torch.zeros_like(rewards)
+for gid in torch.unique(group_ids):
+    mask = group_ids == gid
+    group_rewards = rewards[mask]
+    advantages[mask] = (group_rewards - group_rewards.mean()) / (group_rewards.std(unbiased=False) + 1e-8)
+
+ratio = torch.exp(new_log_probs - old_log_probs)
+unclipped = ratio * advantages
+clipped = torch.clamp(ratio, 0.8, 1.2) * advantages
+expected = -torch.minimum(unclipped, clipped).mean()
+assert torch.allclose(loss, expected, atol=1e-6), f'Loss mismatch: {loss} vs {expected}'
+""",
+        },
+        {
+            "name": "Invariant to per-group reward shifts",
+            "code": """
+import torch
+old_log_probs = torch.log(torch.tensor([0.2, 0.4, 0.5, 0.1], dtype=torch.float32))
+new_log_probs = torch.log(torch.tensor([0.25, 0.35, 0.45, 0.12], dtype=torch.float32))
+rewards = torch.tensor([1.0, 2.0, 10.0, 11.0], dtype=torch.float32)
+shifted = torch.tensor([101.0, 102.0, -5.0, -4.0], dtype=torch.float32)
+group_ids = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+loss_a = {fn}(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2)
+loss_b = {fn}(old_log_probs, new_log_probs, shifted, group_ids, clip_eps=0.2)
+assert torch.allclose(loss_a, loss_b, atol=1e-6), f'Per-group shifts should not change the loss: {loss_a} vs {loss_b}'
+""",
+        },
+        {
+            "name": "Single-item groups have zero advantage",
+            "code": """
+import torch
+old_log_probs = torch.zeros(3)
+new_log_probs = torch.tensor([0.1, -0.2, 0.3])
+rewards = torch.tensor([5.0, 6.0, 7.0])
+group_ids = torch.tensor([0, 1, 2], dtype=torch.int64)
+loss = {fn}(old_log_probs, new_log_probs, rewards, group_ids, clip_eps=0.2)
+assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6), f'Single-item groups should produce zero normalized advantage, got {loss}'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/kmeans.py
+++ b/torch_judge/tasks/kmeans.py
@@ -1,0 +1,88 @@
+"""K-Means clustering task."""
+
+TASK = {
+    "title": "K-Means Clustering",
+    "difficulty": "Medium",
+    "function_name": "kmeans",
+    "hint": (
+        "Initialize centroids from the first k points for deterministic behavior. "
+        "Then alternate: assign each point to the nearest centroid, and recompute "
+        "each centroid as the mean of its assigned points. If a cluster is empty, "
+        "keep its previous centroid."
+    ),
+    "tests": [
+        {
+            "name": "Output shapes",
+            "code": """
+import torch
+x = torch.tensor([
+    [0.0, 0.0],
+    [5.0, 5.0],
+    [0.2, -0.1],
+    [4.8, 5.2],
+], dtype=torch.float32)
+centroids, assignments = {fn}(x, num_clusters=2, num_iters=4)
+assert centroids.shape == (2, 2), f'Centroid shape mismatch: {centroids.shape}'
+assert assignments.shape == (4,), f'Assignment shape mismatch: {assignments.shape}'
+assert assignments.dtype in (torch.int32, torch.int64), f'Assignments should be integer typed, got {assignments.dtype}'
+""",
+        },
+        {
+            "name": "Finds two simple clusters",
+            "code": """
+import torch
+x = torch.tensor([
+    [0.0, 0.0],
+    [5.0, 5.0],
+    [0.0, 1.0],
+    [1.0, 0.0],
+    [5.0, 6.0],
+    [6.0, 5.0],
+], dtype=torch.float32)
+centroids, assignments = {fn}(x, num_clusters=2, num_iters=10)
+expected = torch.tensor([[1.0 / 3.0, 1.0 / 3.0], [16.0 / 3.0, 16.0 / 3.0]])
+assert torch.allclose(centroids, expected, atol=1e-4), f'Wrong centroids: {centroids} vs {expected}'
+assert torch.equal(assignments[[0, 2, 3]], torch.zeros(3, dtype=assignments.dtype)), f'First cluster assignments wrong: {assignments}'
+assert torch.equal(assignments[[1, 4, 5]], torch.ones(3, dtype=assignments.dtype)), f'Second cluster assignments wrong: {assignments}'
+""",
+        },
+        {
+            "name": "Matches nearest-centroid rule after convergence",
+            "code": """
+import torch
+x = torch.tensor([
+    [0.0, 0.0],
+    [10.0, 10.0],
+    [0.2, 0.1],
+    [9.9, 10.2],
+    [0.1, -0.2],
+    [10.1, 9.8],
+], dtype=torch.float32)
+centroids, assignments = {fn}(x, num_clusters=2, num_iters=8)
+distances = torch.cdist(x, centroids)
+expected_assignments = distances.argmin(dim=1)
+assert torch.equal(assignments, expected_assignments), 'Assignments are not the nearest centroids'
+""",
+        },
+        {
+            "name": "Empty clusters keep previous centroid",
+            "code": """
+import torch
+x = torch.tensor([
+    [0.0, 0.0],
+    [10.0, 10.0],
+    [10.0, 10.0],
+    [10.0, 10.0],
+], dtype=torch.float32)
+centroids, assignments = {fn}(x, num_clusters=3, num_iters=5)
+expected = torch.tensor([
+    [0.0, 0.0],
+    [10.0, 10.0],
+    [10.0, 10.0],
+], dtype=torch.float32)
+assert torch.allclose(centroids, expected, atol=1e-5), f'Unexpected centroids with empty cluster: {centroids}'
+assert assignments.shape == (4,), 'Assignments shape changed unexpectedly'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/knn.py
+++ b/torch_judge/tasks/knn.py
@@ -1,0 +1,73 @@
+"""K-Nearest Neighbors classification task."""
+
+TASK = {
+    "title": "K-Nearest Neighbors Classification",
+    "difficulty": "Easy",
+    "function_name": "knn_predict",
+    "hint": (
+        "Compute pairwise distances from each query to each training point, take the "
+        "k smallest distances, gather their labels, and use majority vote. For ties, "
+        "torch.bincount(...).argmax() gives the smallest label."
+    ),
+    "tests": [
+        {
+            "name": "Output shape and dtype",
+            "code": """
+import torch
+x_train = torch.tensor([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0]])
+y_train = torch.tensor([0, 0, 1])
+x_query = torch.tensor([[0.1, 0.2], [2.5, 2.8]])
+pred = {fn}(x_train, y_train, x_query, k=1)
+assert pred.shape == (2,), f'Prediction shape mismatch: {pred.shape}'
+assert pred.dtype in (torch.int32, torch.int64), f'Predictions should be integer labels, got {pred.dtype}'
+""",
+        },
+        {
+            "name": "1-NN matches nearest label",
+            "code": """
+import torch
+x_train = torch.tensor([[0.0, 0.0], [10.0, 10.0], [20.0, 20.0]])
+y_train = torch.tensor([1, 3, 5])
+x_query = torch.tensor([[0.2, -0.1], [11.0, 9.5], [18.0, 19.0]])
+pred = {fn}(x_train, y_train, x_query, k=1)
+expected = torch.tensor([1, 3, 5])
+assert torch.equal(pred, expected), f'Wrong nearest-neighbor predictions: {pred} vs {expected}'
+""",
+        },
+        {
+            "name": "Majority vote with k=3",
+            "code": """
+import torch
+x_train = torch.tensor([
+    [0.0, 0.0],
+    [0.0, 1.0],
+    [1.0, 0.0],
+    [4.0, 4.0],
+    [4.0, 5.0],
+], dtype=torch.float32)
+y_train = torch.tensor([0, 0, 1, 1, 1])
+x_query = torch.tensor([[0.2, 0.2], [4.2, 4.1]])
+pred = {fn}(x_train, y_train, x_query, k=3)
+expected = torch.tensor([0, 1])
+assert torch.equal(pred, expected), f'Majority vote failed: {pred} vs {expected}'
+""",
+        },
+        {
+            "name": "Tie breaks to smaller label",
+            "code": """
+import torch
+x_train = torch.tensor([
+    [0.0, 0.0],
+    [0.0, 2.0],
+    [2.0, 0.0],
+    [2.0, 2.0],
+], dtype=torch.float32)
+y_train = torch.tensor([2, 1, 1, 2])
+x_query = torch.tensor([[1.0, 1.0]])
+pred = {fn}(x_train, y_train, x_query, k=4)
+expected = torch.tensor([1])
+assert torch.equal(pred, expected), f'Tie-breaking should pick the smaller label: {pred} vs {expected}'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/mlp_backward.py
+++ b/torch_judge/tasks/mlp_backward.py
@@ -1,0 +1,78 @@
+"""Hand-written backward pass for a two-layer MLP."""
+
+TASK = {
+    "title": "Hand-Written Backward for a 2-Layer MLP",
+    "difficulty": "Hard",
+    "function_name": "mlp_backward",
+    "hint": (
+        "Forward: z1 = x @ w1.T + b1, h = ReLU(z1), y = h @ w2.T + b2, "
+        "loss = mean((y - target)^2). Backprop from the MSE loss manually, "
+        "then multiply by the ReLU mask (z1 > 0)."
+    ),
+    "tests": [
+        {
+            "name": "Returns all gradient tensors",
+            "code": """
+import torch
+x = torch.randn(4, 3)
+w1 = torch.randn(5, 3)
+b1 = torch.randn(5)
+w2 = torch.randn(2, 5)
+b2 = torch.randn(2)
+target = torch.randn(4, 2)
+grads = {fn}(x, w1, b1, w2, b2, target)
+assert set(grads.keys()) == {'w1', 'b1', 'w2', 'b2'}, f'Wrong gradient keys: {grads.keys()}'
+assert grads['w1'].shape == w1.shape
+assert grads['b1'].shape == b1.shape
+assert grads['w2'].shape == w2.shape
+assert grads['b2'].shape == b2.shape
+""",
+        },
+        {
+            "name": "Matches autograd",
+            "code": """
+import torch
+torch.manual_seed(0)
+x = torch.randn(6, 4)
+w1 = torch.randn(7, 4)
+b1 = torch.randn(7)
+w2 = torch.randn(3, 7)
+b2 = torch.randn(3)
+target = torch.randn(6, 3)
+grads = {fn}(x, w1, b1, w2, b2, target)
+
+w1_ref = w1.clone().requires_grad_(True)
+b1_ref = b1.clone().requires_grad_(True)
+w2_ref = w2.clone().requires_grad_(True)
+b2_ref = b2.clone().requires_grad_(True)
+
+z1 = x @ w1_ref.T + b1_ref
+h = torch.relu(z1)
+out = h @ w2_ref.T + b2_ref
+loss = ((out - target) ** 2).mean()
+loss.backward()
+
+assert torch.allclose(grads['w1'], w1_ref.grad, atol=1e-5), 'w1 gradient mismatch'
+assert torch.allclose(grads['b1'], b1_ref.grad, atol=1e-5), 'b1 gradient mismatch'
+assert torch.allclose(grads['w2'], w2_ref.grad, atol=1e-5), 'w2 gradient mismatch'
+assert torch.allclose(grads['b2'], b2_ref.grad, atol=1e-5), 'b2 gradient mismatch'
+""",
+        },
+        {
+            "name": "ReLU blocks negative hidden units",
+            "code": """
+import torch
+x = torch.tensor([[1.0, 1.0]])
+w1 = torch.tensor([[-2.0, -2.0], [1.0, 1.0]])
+b1 = torch.tensor([-1.0, 0.0])
+w2 = torch.tensor([[3.0, 4.0]])
+b2 = torch.tensor([0.0])
+target = torch.tensor([[1.0]])
+grads = {fn}(x, w1, b1, w2, b2, target)
+assert torch.allclose(grads['w1'][0], torch.zeros_like(grads['w1'][0])), 'Negative ReLU unit should have zero weight gradient'
+assert torch.allclose(grads['b1'][0], torch.tensor(0.0)), 'Negative ReLU unit should have zero bias gradient'
+assert grads['w1'][1].abs().sum() > 0, 'Active ReLU unit should receive gradient'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/ppo_loss.py
+++ b/torch_judge/tasks/ppo_loss.py
@@ -1,0 +1,56 @@
+"""PPO clipped policy loss task."""
+
+TASK = {
+    "title": "PPO Clipped Policy Loss",
+    "difficulty": "Hard",
+    "function_name": "ppo_clipped_loss",
+    "hint": (
+        "Compute ratio = exp(new_log_probs - old_log_probs). Then form the unclipped "
+        "objective ratio * advantages and the clipped one clamp(ratio, 1-eps, 1+eps) "
+        "* advantages. PPO uses the minimum of the two, and the loss is the negative mean."
+    ),
+    "tests": [
+        {
+            "name": "Matches reference formula",
+            "code": """
+import torch
+old_log_probs = torch.log(torch.tensor([0.2, 0.5, 0.3], dtype=torch.float32))
+new_log_probs = torch.log(torch.tensor([0.25, 0.45, 0.30], dtype=torch.float32))
+advantages = torch.tensor([1.0, -0.5, 2.0], dtype=torch.float32)
+loss = {fn}(old_log_probs, new_log_probs, advantages, clip_eps=0.2)
+ratio = torch.exp(new_log_probs - old_log_probs)
+unclipped = ratio * advantages
+clipped = torch.clamp(ratio, 0.8, 1.2) * advantages
+expected = -torch.minimum(unclipped, clipped).mean()
+assert torch.allclose(loss, expected, atol=1e-6), f'Loss mismatch: {loss} vs {expected}'
+""",
+        },
+        {
+            "name": "Positive advantages are clipped when ratio is too large",
+            "code": """
+import torch
+old_log_probs = torch.zeros(3)
+new_log_probs = torch.log(torch.tensor([2.0, 2.5, 3.0]))
+advantages = torch.ones(3)
+loss = {fn}(old_log_probs, new_log_probs, advantages, clip_eps=0.1)
+expected = -torch.tensor(1.1)
+assert torch.allclose(loss, expected, atol=1e-6), f'Expected clipped objective mean -1.1, got {loss}'
+""",
+        },
+        {
+            "name": "Negative advantages use clipped lower ratio",
+            "code": """
+import torch
+old_log_probs = torch.zeros(2)
+new_log_probs = torch.log(torch.tensor([0.2, 0.5]))
+advantages = torch.tensor([-1.0, -2.0])
+loss = {fn}(old_log_probs, new_log_probs, advantages, clip_eps=0.1)
+ratio = torch.exp(new_log_probs - old_log_probs)
+unclipped = ratio * advantages
+clipped = torch.clamp(ratio, 0.9, 1.1) * advantages
+expected = -torch.minimum(unclipped, clipped).mean()
+assert torch.allclose(loss, expected, atol=1e-6), 'Negative-advantage clipping mismatch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/temperature_sampling.py
+++ b/torch_judge/tasks/temperature_sampling.py
@@ -1,0 +1,48 @@
+"""Temperature sampling task."""
+
+TASK = {
+    "title": "Temperature Sampling",
+    "difficulty": "Medium",
+    "function_name": "temperature_sample",
+    "hint": (
+        "Scale logits by dividing by temperature before softmax. Lower temperature makes "
+        "the distribution sharper; higher temperature makes it flatter. Then sample with "
+        "torch.multinomial."
+    ),
+    "tests": [
+        {
+            "name": "Returns one token per row",
+            "code": """
+import torch
+torch.manual_seed(0)
+logits = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+out = {fn}(logits, temperature=0.7)
+assert out.shape == (2,), f'Expected one sample per row, got {out.shape}'
+assert out.dtype in (torch.int32, torch.int64), f'Output should be integer typed, got {out.dtype}'
+""",
+        },
+        {
+            "name": "Matches reference sampling with fixed seed",
+            "code": """
+import torch
+logits = torch.tensor([[2.0, 0.5, -1.0], [0.1, 0.2, 0.3]], dtype=torch.float32)
+torch.manual_seed(42)
+out = {fn}(logits, temperature=0.8)
+torch.manual_seed(42)
+probs = torch.softmax(logits / 0.8, dim=-1)
+expected = torch.multinomial(probs, num_samples=1).squeeze(-1)
+assert torch.equal(out, expected), f'Wrong sampled tokens: {out} vs {expected}'
+""",
+        },
+        {
+            "name": "Very low temperature behaves greedily",
+            "code": """
+import torch
+logits = torch.tensor([0.0, 5.0, 1.0], dtype=torch.float32)
+torch.manual_seed(0)
+out = {fn}(logits, temperature=1e-4)
+assert out.item() == 1, f'Low temperature should almost always pick argmax, got {out.item()}'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/top_k_sampling.py
+++ b/torch_judge/tasks/top_k_sampling.py
@@ -1,0 +1,50 @@
+"""Top-k sampling task."""
+
+TASK = {
+    "title": "Top-k Sampling",
+    "difficulty": "Medium",
+    "function_name": "top_k_sample",
+    "hint": (
+        "Find the top-k logits, mask all other logits to -inf, apply softmax over the "
+        "remaining tokens, then sample from that truncated distribution."
+    ),
+    "tests": [
+        {
+            "name": "Samples only from top-k tokens",
+            "code": """
+import torch
+torch.manual_seed(0)
+logits = torch.tensor([[5.0, 4.0, 1.0, -2.0]])
+out = {fn}(logits, k=2)
+assert out.item() in (0, 1), f'Sampled token must be in the top-2 set, got {out.item()}'
+""",
+        },
+        {
+            "name": "Matches reference sampling with fixed seed",
+            "code": """
+import torch
+logits = torch.tensor([[2.0, 1.5, 0.1, -1.0], [0.2, 3.0, 2.5, 0.0]], dtype=torch.float32)
+torch.manual_seed(123)
+out = {fn}(logits, k=2)
+
+torch.manual_seed(123)
+top_values, top_indices = torch.topk(logits, k=2, dim=-1)
+masked = torch.full_like(logits, float('-inf'))
+masked.scatter_(-1, top_indices, top_values)
+probs = torch.softmax(masked, dim=-1)
+expected = torch.multinomial(probs, num_samples=1).squeeze(-1)
+assert torch.equal(out, expected), f'Sampled tokens mismatch: {out} vs {expected}'
+""",
+        },
+        {
+            "name": "k=1 equals greedy",
+            "code": """
+import torch
+logits = torch.tensor([[0.2, 1.7, 0.8], [3.0, 2.0, 1.0]])
+out = {fn}(logits, k=1)
+expected = logits.argmax(dim=-1)
+assert torch.equal(out, expected), f'k=1 should be greedy: {out} vs {expected}'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/top_p_sampling.py
+++ b/torch_judge/tasks/top_p_sampling.py
@@ -1,0 +1,66 @@
+"""Top-p (nucleus) sampling task."""
+
+TASK = {
+    "title": "Top-p Sampling",
+    "difficulty": "Hard",
+    "function_name": "top_p_sample",
+    "hint": (
+        "Sort tokens by probability descending, take the smallest prefix whose cumulative "
+        "probability reaches p, mask the rest, renormalize, and sample from that nucleus."
+    ),
+    "tests": [
+        {
+            "name": "Samples only from nucleus set",
+            "code": """
+import torch
+torch.manual_seed(0)
+logits = torch.tensor([[4.0, 3.5, 1.0, -2.0]], dtype=torch.float32)
+out = {fn}(logits, p=0.8)
+assert out.item() in (0, 1), f'Sampled token must come from the nucleus set, got {out.item()}'
+""",
+        },
+        {
+            "name": "Matches reference sampling with fixed seed",
+            "code": """
+import torch
+
+def reference_top_p(logits: torch.Tensor, p: float) -> torch.Tensor:
+    if logits.dim() == 1:
+        logits = logits.unsqueeze(0)
+    probs = torch.softmax(logits, dim=-1)
+    outputs = []
+    for row in probs:
+        sorted_probs, sorted_indices = torch.sort(row, descending=True)
+        cumulative = sorted_probs.cumsum(dim=0)
+        keep = cumulative <= p
+        keep[0] = True
+        first_exceed = torch.nonzero(cumulative > p, as_tuple=False)
+        if first_exceed.numel() > 0:
+            keep[first_exceed[0, 0]] = True
+        filtered = torch.zeros_like(row)
+        filtered[sorted_indices[keep]] = row[sorted_indices[keep]]
+        filtered = filtered / filtered.sum()
+        token = torch.multinomial(filtered, num_samples=1)
+        outputs.append(token)
+    return torch.stack(outputs).squeeze(-1)
+
+logits = torch.tensor([[2.5, 2.0, 1.0, -0.5], [0.1, 0.2, 3.0, 2.9]], dtype=torch.float32)
+torch.manual_seed(9)
+out = {fn}(logits, p=0.75)
+torch.manual_seed(9)
+expected = reference_top_p(logits, p=0.75)
+assert torch.equal(out, expected), f'Sampled tokens mismatch: {out} vs {expected}'
+""",
+        },
+        {
+            "name": "Small p still keeps at least one token",
+            "code": """
+import torch
+logits = torch.tensor([1.0, 5.0, 0.5], dtype=torch.float32)
+torch.manual_seed(0)
+out = {fn}(logits, p=0.01)
+assert out.item() == 1, f'At least the top token must remain available, got {out.item()}'
+""",
+        },
+    ],
+}


### PR DESCRIPTION
 This PR expands HappyTorch with 11 new practice problems covering classical ML, decoding/sampling strategies, and RLHF-style objectives.

  Added problems:

  - K-Means clustering
  - KNN classification
  - Hand-written backward pass for a 2-layer MLP
  - Greedy search decoding
  - Beam search decoding
  - Temperature sampling
  - Top-k sampling
  - Top-p sampling
  - PPO clipped loss
  - DPO loss
  - GRPO loss

  Each problem includes:

  - a new task definition in torch_judge/tasks/
  - a blank practice notebook in templates/
  - a reference solution notebook in solutions/
