### PR TITLE
bug fix: softmax attention wrong description

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -120,7 +120,7 @@ def _find_notebook_path(task_id: str, directory: str, suffix: str = "") -> Path 
             return exact
 
     # Try with number prefix (e.g., 01_relu.ipynb or 01_relu_solution.ipynb)
-    for f in base_dir.glob(f"*{suffix}.ipynb"):
+    for f in sorted(base_dir.glob(f"*{suffix}.ipynb")):
         name = f.stem  # "01_relu" or "01_relu_solution"
         # Remove suffix to get base name
         base = name.removesuffix(suffix) if suffix else name


### PR DESCRIPTION
Because `multihead_attention.ipynb` and `attention.ipynb` share the same suffix, the `softmax attention` challenge is incorrectly matched to `multihead_attention.ipynb` rather than `attention.ipynb`, which leads to the wrong template and solution being selected.

This PR adds sorting to fix the issue for now. However, this is only a temporary workaround. A better long-term solution would be to maintain a mapping between `task_id` and the corresponding notebook file.