### PR TITLE
feat: add submission history tracking for web mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .ipynb_checkpoints/
 data/progress.json
+data/submissions.json
 data/*.db
 .DS_Store
 notebooks/

--- a/torch_judge/submissions.py
+++ b/torch_judge/submissions.py
@@ -1,0 +1,72 @@
+"""Track submission history in a local JSON file."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+SUBMISSIONS_PATH = os.environ.get("SUBMISSIONS_PATH", "data/submissions.json")
+MAX_PER_TASK = 20
+
+
+def _load() -> dict[str, list[dict[str, Any]]]:
+    path = Path(SUBMISSIONS_PATH)
+    if path.exists():
+        with open(path) as f:
+            return json.load(f)
+    return {}
+
+
+def _save(data: dict[str, list[dict[str, Any]]]) -> None:
+    path = Path(SUBMISSIONS_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def add_submission(
+    task_id: str,
+    code: str,
+    passed: int,
+    total: int,
+    total_time: float,
+    results: list[dict[str, Any]],
+    output: str,
+) -> None:
+    """Record a submission. Auto-evicts oldest when exceeding MAX_PER_TASK."""
+    data = _load()
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "code": code,
+        "passed": passed,
+        "total": total,
+        "success": passed == total,
+        "total_time": total_time,
+        "results": results,
+        "output": output,
+    }
+    task_history = data.get(task_id, [])
+    task_history.append(entry)
+    if len(task_history) > MAX_PER_TASK:
+        task_history = task_history[-MAX_PER_TASK:]
+    data[task_id] = task_history
+    _save(data)
+
+
+def get_submissions(task_id: str) -> list[dict[str, Any]]:
+    """Return submission history for a task, newest first."""
+    data = _load()
+    return list(reversed(data.get(task_id, [])))
+
+
+def clear_submissions(task_id: str | None = None) -> None:
+    """Clear submissions for a specific task, or all if task_id is None."""
+    if task_id is None:
+        _save({})
+    else:
+        data = _load()
+        data.pop(task_id, None)
+        _save(data)

--- a/web/app.py
+++ b/web/app.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from torch_judge.tasks import get_task, list_tasks
 from torch_judge.progress import _load, mark_solved, mark_attempted
+from torch_judge.submissions import add_submission, get_submissions, clear_submissions
 
 app = FastAPI(title="HappyTorch", description="PyTorch Interview Practice Platform")
 
@@ -535,7 +536,18 @@ async def submit_code(request: SubmitRequest):
         raise HTTPException(status_code=404, detail="Task not found")
     
     passed, total, total_time, results, output = _run_tests(request.task_id, request.code)
-    
+
+    # Record submission history
+    add_submission(
+        task_id=request.task_id,
+        code=request.code,
+        passed=passed,
+        total=total,
+        total_time=total_time,
+        results=results,
+        output=output,
+    )
+
     # Update progress
     if passed == total:
         mark_solved(request.task_id, total_time)
@@ -552,11 +564,21 @@ async def submit_code(request: SubmitRequest):
     )
 
 
+@app.get("/api/tasks/{task_id}/submissions")
+async def get_task_submissions(task_id: str):
+    """Get submission history for a task."""
+    task = get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return {"task_id": task_id, "submissions": get_submissions(task_id)}
+
+
 @app.post("/api/reset")
 async def reset_progress():
-    """Reset all progress."""
+    """Reset all progress and submission history."""
     from torch_judge.progress import reset_progress as _reset
     _reset()
+    clear_submissions()
     return {"success": True}
 
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -561,6 +561,91 @@
             white-space: pre;
         }
 
+        /* Submission History */
+        .history-item {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            margin: 0 16px 12px;
+            overflow: hidden;
+        }
+        .history-item.success { border-left: 3px solid var(--success); }
+        .history-item.fail { border-left: 3px solid var(--error); }
+
+        .history-header {
+            padding: 12px 16px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .history-header:hover { background: var(--bg-hover); }
+
+        .history-status { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+
+        .pass-badge {
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 12px;
+            font-weight: 500;
+        }
+        .pass-badge.success { background: rgba(63,185,80,0.2); color: var(--success); }
+        .pass-badge.fail { background: rgba(248,81,73,0.2); color: var(--error); }
+
+        .history-meta {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-size: 12px;
+            color: var(--text-muted);
+        }
+
+        .history-detail {
+            display: none;
+            border-top: 1px solid var(--border);
+        }
+        .history-detail.show { display: block; }
+
+        .history-code-section {
+            padding: 12px 16px;
+            border-bottom: 1px solid var(--border);
+        }
+        .history-code-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+        .history-code-block {
+            background: var(--bg-primary);
+            padding: 12px;
+            border-radius: 6px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px;
+            white-space: pre-wrap;
+            overflow-x: auto;
+            max-height: 300px;
+            overflow-y: auto;
+            margin: 0;
+            color: var(--text-primary);
+        }
+        .history-results-section { padding: 8px 16px 12px; }
+
+        .btn-load-code {
+            padding: 4px 10px;
+            border-radius: 4px;
+            font-size: 11px;
+            background: var(--accent);
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .btn-load-code:hover { background: var(--accent-hover); }
+
         /* Results Panel */
         .results-panel {
             background: var(--bg-secondary);
@@ -916,6 +1001,7 @@
                     <button class="tab-btn active" data-tab="code">代码</button>
                     <button class="tab-btn" data-tab="description">题目描述</button>
                     <button class="tab-btn" data-tab="solution" id="solutionTabBtn" style="display: none;">题解</button>
+                    <button class="tab-btn" data-tab="history">提交记录</button>
                 </div>
 
                 <div class="editor-container" id="codeTab">
@@ -960,6 +1046,15 @@
                             <pre class="solution-code-block"><code id="solutionCode"></code></pre>
                         </div>
                     </div>
+                </div>
+
+                <div class="description-panel" id="historyTab" style="display: none;">
+                    <div id="historyLoading" style="color: var(--text-secondary); padding: 20px;">加载提交记录中...</div>
+                    <div id="historyEmpty" style="display: none; color: var(--text-secondary); padding: 20px; text-align: center;">
+                        <i class="ri-history-line" style="font-size: 32px; display: block; margin-bottom: 8px; color: var(--text-muted);"></i>
+                        暂无提交记录
+                    </div>
+                    <div id="historyList" style="display: none; padding-top: 12px;"></div>
                 </div>
 
                 <div class="results-panel" id="resultsPanel">
@@ -1299,10 +1394,15 @@
             document.getElementById('codeTab').style.display = tab === 'code' ? 'flex' : 'none';
             document.getElementById('descriptionTab').style.display = tab === 'description' ? 'block' : 'none';
             document.getElementById('solutionTab').style.display = tab === 'solution' ? 'block' : 'none';
+            document.getElementById('historyTab').style.display = tab === 'history' ? 'block' : 'none';
 
             // Lazy-load solution on first tab switch
             if (tab === 'solution' && currentTask && !currentTask._solutionLoaded) {
                 loadSolution(currentTask.id);
+            }
+            // Always reload history when switching to the tab
+            if (tab === 'history' && currentTask) {
+                loadHistory(currentTask.id);
             }
         }
 
@@ -1355,6 +1455,97 @@
             }).catch(() => {
                 showToast('复制失败', 'error');
             });
+        }
+
+        // Submission History
+        let _currentSubmissions = [];
+
+        async function loadHistory(taskId) {
+            const loading = document.getElementById('historyLoading');
+            const empty = document.getElementById('historyEmpty');
+            const list = document.getElementById('historyList');
+
+            loading.style.display = 'block';
+            empty.style.display = 'none';
+            list.style.display = 'none';
+            _currentSubmissions = [];
+
+            try {
+                const res = await fetch(`${API_BASE}/api/tasks/${taskId}/submissions`);
+                const data = await res.json();
+                const submissions = data.submissions;
+                _currentSubmissions = submissions;
+
+                loading.style.display = 'none';
+
+                if (!submissions || submissions.length === 0) {
+                    empty.style.display = 'block';
+                    return;
+                }
+
+                list.style.display = 'block';
+                list.innerHTML = submissions.map((s, i) => {
+                    const date = new Date(s.timestamp);
+                    const timeStr = date.toLocaleString('zh-CN');
+                    const statusClass = s.success ? 'success' : 'fail';
+                    const statusText = s.success ? '通过' : '未通过';
+                    const execTime = (s.total_time * 1000).toFixed(1);
+
+                    return `
+                        <div class="history-item ${statusClass}">
+                            <div class="history-header" onclick="toggleHistoryDetail(${i})">
+                                <div class="history-status">
+                                    <span class="pass-badge ${statusClass}">${s.passed}/${s.total} ${statusText}</span>
+                                </div>
+                                <div class="history-meta">
+                                    <span>${execTime}ms</span>
+                                    <span>${timeStr}</span>
+                                    <i class="ri-arrow-down-s-line"></i>
+                                </div>
+                            </div>
+                            <div class="history-detail" id="historyDetail-${i}">
+                                <div class="history-code-section">
+                                    <div class="history-code-header">
+                                        <span>提交代码</span>
+                                        <button class="btn-load-code" onclick="loadHistoryCode(${i}); event.stopPropagation();">
+                                            <i class="ri-upload-2-line"></i> 加载到编辑器
+                                        </button>
+                                    </div>
+                                    <pre class="history-code-block">${escapeHtml(s.code)}</pre>
+                                </div>
+                                <div class="history-results-section">
+                                    ${s.results.map((r, j) => `
+                                        <div class="result-item ${r.passed ? 'passed' : 'failed'}">
+                                            <div class="result-name">
+                                                <span class="result-icon">${r.passed ? '✓' : '✗'}</span>
+                                                <span>Test ${j + 1}: ${escapeHtml(r.name)}</span>
+                                            </div>
+                                            <span class="result-time">${(r.time * 1000).toFixed(1)}ms</span>
+                                        </div>
+                                        ${r.error ? `<div class="result-error">${escapeHtml(r.error)}</div>` : ''}
+                                    `).join('')}
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
+            } catch (e) {
+                console.error('Failed to load history:', e);
+                loading.textContent = '加载提交记录失败';
+            }
+        }
+
+        function toggleHistoryDetail(index) {
+            const detail = document.getElementById(`historyDetail-${index}`);
+            detail.classList.toggle('show');
+        }
+
+        function loadHistoryCode(index) {
+            if (_currentSubmissions[index] && editor) {
+                editor.setValue(_currentSubmissions[index].code);
+                switchTab('code');
+                showToast('已加载历史代码', 'success');
+            }
         }
 
         function showResults(result) {


### PR DESCRIPTION
## Summary

- Add `torch_judge/submissions.py`: stores per-task submission records (code, test results, timestamp, pass/fail) in `data/submissions.json`, capped at 20 entries per task with automatic FIFO eviction
- Hook `add_submission()` into `POST /api/submit` so every test run is recorded as a side effect alongside progress tracking
- Add `GET /api/tasks/{task_id}/submissions` API endpoint returning history newest-first
- Extend `POST /api/reset` to also clear submission history
- Add a **"提交记录" tab** in the Web UI with collapsible history cards showing: pass/fail badge, execution time, timestamp, per-test breakdown, and a "load to editor" button to restore any historical submission code

## Test plan

- [ ] Start web server: `python start_web.py`
- [ ] Select any task, submit code 2–3 times (mix of passing and failing)
- [ ] Click the "提交记录" tab — verify records appear newest-first with correct pass/fail colors
- [ ] Expand a record — verify submitted code and per-test details are shown
- [ ] Click "加载到编辑器" — verify the historical code is loaded into Monaco and tab switches to code view
- [ ] Confirm `data/submissions.json` is created with correct structure
- [ ] Call `POST /api/reset` — verify submission history is cleared along with progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)