### PR TITLE
feat: add 9 problems — flow matching, DMD2, CFG, and a NumPy neural-n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python](https://img.shields.io/badge/Python_3.11-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](LICENSE)
 
-![Problems](https://img.shields.io/badge/problems-36-orange?style=flat-square)
+![Problems](https://img.shields.io/badge/problems-45-orange?style=flat-square)
 ![GPU](https://img.shields.io/badge/GPU-not%20required-brightgreen?style=flat-square)
 
 > **News**
@@ -33,11 +33,11 @@ If you're learning deep learning or preparing for ML interviews, you might have 
 - You're asked to implement `softmax` or `MultiHeadAttention` in an interview, and your mind goes blank
 - You want to deeply understand Transformer, LoRA, Diffusion, RLHF, but lack systematic practice
 
-**HappyTorch** provides a friendly hands-on practice environment with **36 curated problems**, from basic activation functions to complete Transformer components and RLHF algorithms.
+**HappyTorch** provides a friendly hands-on practice environment with **45 curated problems**, from basic activation functions to complete Transformer components and RLHF algorithms.
 
 | Feature | Description |
 |---------|-------------|
-| **36 curated problems** | From basics to advanced, covering mainstream deep learning topics |
+| **45 curated problems** | From basics to advanced, covering mainstream deep learning topics |
 | **Auto-grading** | Instant feedback showing what you got right and where to improve |
 | **Two interfaces** | LeetCode-like Web UI (Monaco Editor) or Jupyter notebooks |
 | **Helpful hints** | Get nudges when stuck, not full spoilers |
@@ -109,7 +109,7 @@ python start_web.py
 
 ---
 
-## Problem Set (36 Problems)
+## Problem Set (45 Problems)
 
 ### Fundamentals
 
@@ -169,11 +169,14 @@ python start_web.py
 | 22 | RoPE | `apply_rotary_pos_emb(x, pos)` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Rotary embedding, 2D rotation |
 | 23 | KV Cache | `KVCache` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Incremental caching for generation |
 
-### Diffusion Training *(V2)*
+### Diffusion Training *(V2 / V4)*
 
 | # | Problem | Function / Class | Difficulty | Key Concepts |
 |:-:|---------|-----------------|:----------:|--------------|
 | 24 | Sigmoid Schedule | `sigmoid_schedule(t, ...)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | S-curve noise schedule |
+| 37 | Flow Matching Loss | `flow_matching_loss(model, x0, x1, t)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Rectified flow, straight path, velocity regression (SD3 / Flux) |
+| 38 | DMD2 Distribution Matching | `dmd_loss(x_gen, pred_real, pred_fake)` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Reverse-KL as a score difference, gradient surrogate, one-step distillation |
+| 39 | Classifier-Free Guidance | `classifier_free_guidance(eps_u, eps_c, w)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Guided extrapolation, per-sample std rescale |
 
 ### ML Fundamentals & Decoding *(V3 — Community)*
 
@@ -188,6 +191,19 @@ python start_web.py
 | 30 | Temperature Sampling | `temperature_sample` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Temperature-scaled softmax sampling |
 | 31 | Top-k Sampling | `top_k_sample` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Truncated probability distribution |
 | 32 | Top-p Sampling | `top_p_sample` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Nucleus sampling |
+
+### Neural Nets from Scratch in NumPy *(V4)*
+
+No autograd, no `torch` — build the forward pass, cache what you need, then derive every gradient by hand.
+
+| # | Problem | Function / Class | Difficulty | Key Concepts |
+|:-:|---------|-----------------|:----------:|--------------|
+| 40 | MLP Forward | `mlp_forward(X, params)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Affine + ReLU chain, linear logits, shape discipline |
+| 41 | Softmax Cross-Entropy | `softmax_cross_entropy(logits, labels)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Stable softmax, the fused `(p - onehot)/N` gradient |
+| 42 | MLP Backpropagation | `mlp_loss_and_grads(X, labels, params)` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Full L-layer backprop, caching, gradient checking |
+| 43 | Conv2D Forward | `conv2d_forward(x, w, b, stride, padding)` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | Cross-correlation, weight sharing, im2col thinking |
+| 44 | Conv2D Backward | `conv2d_backward(dout, x, w, ...)` | ![Hard](https://img.shields.io/badge/-Hard-F44336?style=flat-square) | dx / dw / db, overlapping-window accumulation |
+| 45 | MaxPool2D Fwd + Bwd | `maxpool2d(x, kernel_size, stride)` | ![Medium](https://img.shields.io/badge/-Medium-FF9800?style=flat-square) | Argmax routing, returning a backward closure |
 
 ### RLHF *(V3 — Community)*
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,7 +11,7 @@
 [![Python](https://img.shields.io/badge/Python_3.11-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](LICENSE)
 
-![Problems](https://img.shields.io/badge/题目数-36-orange?style=flat-square)
+![Problems](https://img.shields.io/badge/题目数-45-orange?style=flat-square)
 ![GPU](https://img.shields.io/badge/GPU-无需-brightgreen?style=flat-square)
 
 > **动态**
@@ -33,11 +33,11 @@
 - 面试被要求从零实现 `softmax` 或 `MultiHeadAttention`，脑子一片空白
 - 想深入理解 Transformer、LoRA、Diffusion、RLHF，但缺乏系统性的动手练习
 
-**HappyTorch** 提供一个友好的实践环境，包含 **36 道精选题目**，从基础激活函数到完整 Transformer 组件和 RLHF 算法，帮助你循序渐进地提升。
+**HappyTorch** 提供一个友好的实践环境，包含 **45 道精选题目**，从基础激活函数到完整 Transformer 组件和 RLHF 算法，帮助你循序渐进地提升。
 
 | 特性 | 说明 |
 |------|------|
-| **36 道精选题目** | 从基础到进阶，覆盖主流深度学习技术栈 |
+| **45 道精选题目** | 从基础到进阶，覆盖主流深度学习技术栈 |
 | **自动评测** | 即时反馈，清晰展示每个测试用例的通过/失败状态 |
 | **双界面** | LeetCode 风格的 Web 界面（Monaco 编辑器）或 Jupyter Notebook |
 | **智能提示** | 卡住时给你思路，而非直接给答案 |
@@ -109,7 +109,7 @@ python start_web.py
 
 ---
 
-## 题目列表（共 36 题）
+## 题目列表（共 45 题）
 
 ### 基础层
 
@@ -169,11 +169,14 @@ python start_web.py
 | 22 | RoPE | `apply_rotary_pos_emb(x, pos)` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | 旋转位置编码，二维旋转 |
 | 23 | KV Cache | `KVCache` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | 增量缓存，文本生成加速 |
 
-### 扩散模型训练 *(V2)*
+### 扩散模型训练 *(V2 / V4)*
 
 | # | 题目 | 函数 / 类 | 难度 | 核心概念 |
 |:-:|------|----------|:----:|----------|
 | 24 | Sigmoid 噪声调度 | `sigmoid_schedule(t, ...)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | S 曲线噪声调度 |
+| 37 | Flow Matching 损失 | `flow_matching_loss(model, x0, x1, t)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 整流流，直线路径，速度场回归（SD3 / Flux） |
+| 38 | DMD2 分布匹配损失 | `dmd_loss(x_gen, pred_real, pred_fake)` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | 反向 KL = 分数差，梯度替代损失，一步蒸馏 |
+| 39 | Classifier-Free Guidance | `classifier_free_guidance(eps_u, eps_c, w)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 引导外推，逐样本标准差 rescale |
 
 ### ML 基础与解码策略 *(V3 — 社区贡献)*
 
@@ -188,6 +191,19 @@ python start_web.py
 | 30 | 温度采样 | `temperature_sample` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 温度缩放 softmax 采样 |
 | 31 | Top-k 采样 | `top_k_sample` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 截断概率分布 |
 | 32 | Top-p 采样 | `top_p_sample` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | 核采样（Nucleus Sampling） |
+
+### NumPy 手写神经网络 *(V4)*
+
+不用 autograd、不用 torch —— 自己写前向、自己缓存中间量、自己推每一个梯度。
+
+| # | 题目 | 函数 / 类 | 难度 | 核心概念 |
+|:-:|------|----------|:----:|----------|
+| 40 | MLP 前向传播 | `mlp_forward(X, params)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 仿射 + ReLU 堆叠，最后一层保持线性，形状约定 |
+| 41 | Softmax 交叉熵 + 梯度 | `softmax_cross_entropy(logits, labels)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | 数值稳定 softmax，融合梯度 `(p - onehot)/N` |
+| 42 | MLP 反向传播 | `mlp_loss_and_grads(X, labels, params)` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | L 层完整反传，前向缓存，数值梯度校验 |
+| 43 | Conv2D 前向 | `conv2d_forward(x, w, b, stride, padding)` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | 互相关（不翻转核），权重共享，im2col 思路 |
+| 44 | Conv2D 反向 | `conv2d_backward(dout, x, w, ...)` | ![Hard](https://img.shields.io/badge/-困难-F44336?style=flat-square) | dx / dw / db，重叠窗口梯度累加 |
+| 45 | MaxPool2D 前向 + 反向 | `maxpool2d(x, kernel_size, stride)` | ![Medium](https://img.shields.io/badge/-中等-FF9800?style=flat-square) | argmax 路由，返回 backward 闭包 |
 
 ### RLHF *(V3 — 社区贡献)*
 

--- a/solutions/37_flow_matching_solution.ipynb
+++ b/solutions/37_flow_matching_solution.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: Flow Matching Loss (Rectified Flow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def flow_matching_loss(model, x0, x1, t):\n",
+    "    # x0: noise (B, ...)   x1: data (B, ...)   t: (B,) in [0, 1]\n",
+    "\n",
+    "    # Reshape t to (B, 1, 1, ...) so it broadcasts over every feature dim\n",
+    "    t = t.view(-1, *([1] * (x1.dim() - 1)))\n",
+    "\n",
+    "    # Straight-line probability path between noise and data\n",
+    "    x_t = (1.0 - t) * x0 + t * x1\n",
+    "\n",
+    "    # Velocity of that path — constant in t\n",
+    "    target = x1 - x0\n",
+    "\n",
+    "    # Regress the velocity field\n",
+    "    v = model(x_t, t)\n",
+    "    return ((v - target) ** 2).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "x0 = torch.randn(8, 4)\n",
+    "x1 = torch.randn(8, 4)\n",
+    "t = torch.rand(8)\n",
+    "\n",
+    "print(\"zero-velocity model :\", flow_matching_loss(lambda x, tt: torch.zeros_like(x), x0, x1, t).item())\n",
+    "print(\"expected            :\", ((x1 - x0) ** 2).mean().item())\n",
+    "print(\"perfect model       :\", flow_matching_loss(lambda x, tt: x1 - x0, x0, x1, t).item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"flow_matching\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/38_dmd2_solution.ipynb
+++ b/solutions/38_dmd2_solution.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: DMD2 Distribution Matching Loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def dmd_loss(x_gen, pred_real, pred_fake, eps=1e-8):\n",
+    "    # Every dim except the batch dim\n",
+    "    dims = tuple(range(1, x_gen.dim()))\n",
+    "\n",
+    "    # Per-sample scale of the teacher's correction — makes the update dimension-free\n",
+    "    normalizer = (pred_real - x_gen).abs().mean(dim=dims, keepdim=True)\n",
+    "\n",
+    "    # Score difference = gradient of the reverse KL w.r.t. the generated sample\n",
+    "    grad = (pred_fake - pred_real) / (normalizer + eps)\n",
+    "    grad = torch.nan_to_num(grad)\n",
+    "\n",
+    "    # Surrogate loss whose derivative IS that gradient (target carries no graph)\n",
+    "    target = (x_gen - grad).detach()\n",
+    "    return 0.5 * F.mse_loss(x_gen, target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "x = torch.randn(4, 3, 8, 8, requires_grad=True)\n",
+    "pred_real = torch.randn(4, 3, 8, 8)\n",
+    "pred_fake = torch.randn(4, 3, 8, 8)\n",
+    "\n",
+    "loss = dmd_loss(x, pred_real, pred_fake)\n",
+    "loss.backward()\n",
+    "normalizer = (pred_real - x.detach()).abs().mean(dim=(1, 2, 3), keepdim=True)\n",
+    "expected = (pred_fake - pred_real) / (normalizer + 1e-8) / x.numel()\n",
+    "print(\"loss           :\", loss.item())\n",
+    "print(\"matches theory :\", torch.allclose(x.grad, expected, atol=1e-6))\n",
+    "print(\"zero when equal:\", dmd_loss(x, pred_real, pred_real).item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"dmd2\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/39_cfg_solution.ipynb
+++ b/solutions/39_cfg_solution.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: Classifier-Free Guidance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def classifier_free_guidance(eps_uncond, eps_cond, guidance_scale, rescale=0.0):\n",
+    "    # Linear extrapolation away from the unconditional prediction\n",
+    "    eps_cfg = eps_uncond + guidance_scale * (eps_cond - eps_uncond)\n",
+    "\n",
+    "    if rescale > 0.0:\n",
+    "        # Per-sample statistics: every dim except the batch dim\n",
+    "        dims = tuple(range(1, eps_cfg.dim()))\n",
+    "        std_cond = eps_cond.std(dim=dims, keepdim=True)\n",
+    "        std_cfg = eps_cfg.std(dim=dims, keepdim=True)\n",
+    "\n",
+    "        # Renormalise back to the conditional branch's scale, then blend\n",
+    "        eps_rescaled = eps_cfg * (std_cond / std_cfg)\n",
+    "        eps_cfg = rescale * eps_rescaled + (1.0 - rescale) * eps_cfg\n",
+    "\n",
+    "    return eps_cfg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "eps_u = torch.randn(4, 3, 8, 8)\n",
+    "eps_c = torch.randn(4, 3, 8, 8)\n",
+    "\n",
+    "out = classifier_free_guidance(eps_u, eps_c, 7.5)\n",
+    "print(\"w=7.5 matches formula :\", torch.allclose(out, eps_u + 7.5 * (eps_c - eps_u), atol=1e-6))\n",
+    "print(\"w=1.0 is conditional  :\", torch.allclose(classifier_free_guidance(eps_u, eps_c, 1.0), eps_c, atol=1e-6))\n",
+    "print(\"std before rescale    :\", out.std(dim=(1, 2, 3)).mean().item())\n",
+    "print(\"std after  rescale    :\", classifier_free_guidance(eps_u, eps_c, 7.5, rescale=1.0).std(dim=(1, 2, 3)).mean().item())\n",
+    "print(\"std of conditional    :\", eps_c.std(dim=(1, 2, 3)).mean().item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"cfg\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/40_numpy_mlp_forward_solution.ipynb
+++ b/solutions/40_numpy_mlp_forward_solution.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: MLP Forward Pass (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def mlp_forward(X, params):\n",
+    "    # X: (N, d_in);  params: list of (W, b), W: (in, out), b: (out,)\n",
+    "    A = X\n",
+    "    last = len(params) - 1\n",
+    "\n",
+    "    for i, (W, b) in enumerate(params):\n",
+    "        Z = A @ W + b                      # affine map, b broadcasts over rows\n",
+    "        A = np.maximum(Z, 0) if i < last else Z   # ReLU on hidden layers only\n",
+    "\n",
+    "    return A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "np.random.seed(0)\n",
+    "X = np.random.randn(5, 4)\n",
+    "params = [(np.random.randn(4, 6), np.random.randn(6)),\n",
+    "          (np.random.randn(6, 3), np.random.randn(3))]\n",
+    "\n",
+    "out = mlp_forward(X, params)\n",
+    "print(\"output shape:\", out.shape)\n",
+    "print(\"one layer == affine:\", np.allclose(mlp_forward(X, [params[0]]), X @ params[0][0] + params[0][1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_mlp_forward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/41_numpy_softmax_ce_solution.ipynb
+++ b/solutions/41_numpy_softmax_ce_solution.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: Softmax Cross-Entropy + Gradient (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def softmax_cross_entropy(logits, labels):\n",
+    "    # logits: (N, C);  labels: (N,) int\n",
+    "    N = logits.shape[0]\n",
+    "    rows = np.arange(N)\n",
+    "\n",
+    "    # Stable softmax: shift by the row max so the largest exponent is e^0 = 1\n",
+    "    z = logits - logits.max(axis=1, keepdims=True)\n",
+    "    exp_z = np.exp(z)\n",
+    "    p = exp_z / exp_z.sum(axis=1, keepdims=True)\n",
+    "\n",
+    "    # Mean negative log-likelihood of the true class\n",
+    "    loss = float(-np.log(p[rows, labels]).mean())\n",
+    "\n",
+    "    # The fused gradient: (predicted - actual) / N\n",
+    "    dlogits = p.copy()\n",
+    "    dlogits[rows, labels] -= 1.0\n",
+    "    dlogits /= N\n",
+    "\n",
+    "    return loss, dlogits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "np.random.seed(0)\n",
+    "logits = np.random.randn(6, 4)\n",
+    "labels = np.array([0, 1, 2, 3, 0, 1])\n",
+    "\n",
+    "loss, dlogits = softmax_cross_entropy(logits, labels)\n",
+    "print(\"loss        :\", loss)\n",
+    "print(\"rows sum ~0 :\", np.allclose(dlogits.sum(axis=1), 0))\n",
+    "\n",
+    "uniform_loss, _ = softmax_cross_entropy(np.zeros((4, 10)), np.array([0, 3, 7, 9]))\n",
+    "print(\"uniform loss:\", uniform_loss, \"== log(10) =\", np.log(10))\n",
+    "\n",
+    "big, _ = softmax_cross_entropy(np.array([[1000.0, 1001.0, 999.0]]), np.array([1]))\n",
+    "print(\"stable      :\", np.isfinite(big))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_softmax_ce\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/42_numpy_mlp_backward_solution.ipynb
+++ b/solutions/42_numpy_mlp_backward_solution.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: MLP Backpropagation (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def mlp_loss_and_grads(X, labels, params):\n",
+    "    # X: (N, d_in);  labels: (N,) int;  params: list of (W, b)\n",
+    "    N = X.shape[0]\n",
+    "    L = len(params)\n",
+    "    rows = np.arange(N)\n",
+    "\n",
+    "    # ---------- forward (cache A_prev and Z for every layer) ----------\n",
+    "    A = X\n",
+    "    cache = []\n",
+    "    for i, (W, b) in enumerate(params):\n",
+    "        Z = A @ W + b\n",
+    "        cache.append((A, Z))\n",
+    "        A = np.maximum(Z, 0) if i < L - 1 else Z\n",
+    "    logits = A\n",
+    "\n",
+    "    # ---------- softmax cross-entropy ----------\n",
+    "    z = logits - logits.max(axis=1, keepdims=True)\n",
+    "    exp_z = np.exp(z)\n",
+    "    p = exp_z / exp_z.sum(axis=1, keepdims=True)\n",
+    "    loss = float(-np.log(p[rows, labels]).mean())\n",
+    "\n",
+    "    # Fused seed gradient: (predicted - actual) / N\n",
+    "    dZ = p.copy()\n",
+    "    dZ[rows, labels] -= 1.0\n",
+    "    dZ /= N\n",
+    "\n",
+    "    # ---------- backward ----------\n",
+    "    grads = [None] * L\n",
+    "    for i in range(L - 1, -1, -1):\n",
+    "        A_prev, _ = cache[i]\n",
+    "        W, _ = params[i]\n",
+    "\n",
+    "        grads[i] = (A_prev.T @ dZ, dZ.sum(axis=0))   # product rule + broadcast rule\n",
+    "\n",
+    "        if i > 0:\n",
+    "            dA_prev = dZ @ W.T\n",
+    "            Z_prev = cache[i - 1][1]\n",
+    "            dZ = dA_prev * (Z_prev > 0)              # ReLU gate\n",
+    "\n",
+    "    return loss, grads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify — gradient check against finite differences, then train\n",
+    "np.random.seed(3)\n",
+    "X = np.random.randn(5, 3)\n",
+    "labels = np.array([0, 1, 2, 1, 0])\n",
+    "params = [(np.random.randn(3, 4), np.random.randn(4)), (np.random.randn(4, 3), np.random.randn(3))]\n",
+    "\n",
+    "loss, grads = mlp_loss_and_grads(X, labels, params)\n",
+    "W = params[0][0]\n",
+    "eps = 1e-6\n",
+    "num = np.zeros_like(W)\n",
+    "for i in range(W.shape[0]):\n",
+    "    for j in range(W.shape[1]):\n",
+    "        orig = W[i, j]\n",
+    "        W[i, j] = orig + eps; lp, _ = mlp_loss_and_grads(X, labels, params)\n",
+    "        W[i, j] = orig - eps; lm, _ = mlp_loss_and_grads(X, labels, params)\n",
+    "        W[i, j] = orig\n",
+    "        num[i, j] = (lp - lm) / (2 * eps)\n",
+    "\n",
+    "print(\"max |analytic - numerical|:\", np.abs(grads[0][0] - num).max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_mlp_backward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/43_numpy_conv2d_solution.ipynb
+++ b/solutions/43_numpy_conv2d_solution.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: Conv2D Forward (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def conv2d_forward(x, w, b, stride=1, padding=0):\n",
+    "    # x: (N, C, H, W);  w: (F, C, KH, KW);  b: (F,)\n",
+    "    N, C, H, W = x.shape\n",
+    "    F, _, KH, KW = w.shape\n",
+    "    s, p = stride, padding\n",
+    "\n",
+    "    H_out = (H + 2 * p - KH) // s + 1\n",
+    "    W_out = (W + 2 * p - KW) // s + 1\n",
+    "\n",
+    "    # Zero-pad the spatial dims only\n",
+    "    x_pad = np.pad(x, ((0, 0), (0, 0), (p, p), (p, p))) if p > 0 else x\n",
+    "\n",
+    "    out = np.zeros((N, F, H_out, W_out), dtype=np.float64)\n",
+    "\n",
+    "    # Loop over output positions (few); vectorise over N, C, F\n",
+    "    for i in range(H_out):\n",
+    "        for j in range(W_out):\n",
+    "            patch = x_pad[:, :, i * s:i * s + KH, j * s:j * s + KW]   # (N, C, KH, KW)\n",
+    "            # Contract over C, KH, KW -> (N, F). No kernel flip: cross-correlation.\n",
+    "            out[:, :, i, j] = np.tensordot(patch, w, axes=([1, 2, 3], [1, 2, 3])) + b\n",
+    "\n",
+    "    return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "w = np.random.randn(4, 3, 3, 3)\n",
+    "b = np.random.randn(4)\n",
+    "\n",
+    "print(\"stride=1 padding=0:\", conv2d_forward(x, w, b, 1, 0).shape)\n",
+    "print(\"stride=1 padding=1:\", conv2d_forward(x, w, b, 1, 1).shape)\n",
+    "print(\"stride=2 padding=1:\", conv2d_forward(x, w, b, 2, 1).shape)\n",
+    "\n",
+    "ident = np.zeros((1, 1, 3, 3)); ident[0, 0, 1, 1] = 1.0\n",
+    "one = np.random.randn(1, 1, 5, 5)\n",
+    "print(\"identity kernel   :\", np.allclose(conv2d_forward(one, ident, np.zeros(1), 1, 1), one))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_conv2d\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/44_numpy_conv2d_backward_solution.ipynb
+++ b/solutions/44_numpy_conv2d_backward_solution.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Solution: Conv2D Backward (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def conv2d_backward(dout, x, w, stride=1, padding=0):\n",
+    "    # dout: (N, F, H_out, W_out);  x: (N, C, H, W);  w: (F, C, KH, KW)\n",
+    "    N, C, H, W = x.shape\n",
+    "    F, _, KH, KW = w.shape\n",
+    "    _, _, H_out, W_out = dout.shape\n",
+    "    s, p = stride, padding\n",
+    "\n",
+    "    x_pad = np.pad(x, ((0, 0), (0, 0), (p, p), (p, p))) if p > 0 else x\n",
+    "\n",
+    "    dx_pad = np.zeros_like(x_pad, dtype=np.float64)\n",
+    "    dw = np.zeros_like(w, dtype=np.float64)\n",
+    "\n",
+    "    # The bias is broadcast over batch and space -> sum the gradient back over those dims\n",
+    "    db = dout.sum(axis=(0, 2, 3))\n",
+    "\n",
+    "    for i in range(H_out):\n",
+    "        for j in range(W_out):\n",
+    "            d = dout[:, :, i, j]                                      # (N, F)\n",
+    "            patch = x_pad[:, :, i * s:i * s + KH, j * s:j * s + KW]    # (N, C, KH, KW)\n",
+    "\n",
+    "            # dw: contract over the batch -> (F, C, KH, KW). Weight sharing means we accumulate.\n",
+    "            dw += np.tensordot(d, patch, axes=([0], [0]))\n",
+    "\n",
+    "            # dx: scatter the gradient back through the same window. Overlaps must add up.\n",
+    "            dx_pad[:, :, i * s:i * s + KH, j * s:j * s + KW] += np.tensordot(d, w, axes=([1], [0]))\n",
+    "\n",
+    "    # Crop the padded border so dx has the shape of x\n",
+    "    dx = dx_pad[:, :, p:p + H, p:p + W]\n",
+    "\n",
+    "    return dx, dw, db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "w = np.random.randn(4, 3, 3, 3)\n",
+    "dout = np.random.randn(2, 4, 6, 6)\n",
+    "\n",
+    "dx, dw, db = conv2d_backward(dout, x, w, stride=1, padding=0)\n",
+    "print(\"dx:\", dx.shape, \" dw:\", dw.shape, \" db:\", db.shape)\n",
+    "print(\"db == dout.sum:\", np.allclose(db, dout.sum(axis=(0, 2, 3))))\n",
+    "\n",
+    "xs = np.zeros((1, 1, 4, 4))\n",
+    "ws = np.ones((1, 1, 2, 2))\n",
+    "dxs, _, _ = conv2d_backward(np.ones((1, 1, 3, 3)), xs, ws, stride=1, padding=0)\n",
+    "print(\"corner pixel  :\", dxs[0, 0, 0, 0], \"(expect 1.0)\")\n",
+    "print(\"interior pixel:\", dxs[0, 0, 1, 1], \"(expect 4.0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_conv2d_backward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/solutions/45_numpy_maxpool2d_solution.ipynb
+++ b/solutions/45_numpy_maxpool2d_solution.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Solution: MaxPool2D Forward & Backward (NumPy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SOLUTION\n",
+    "\n",
+    "def maxpool2d(x, kernel_size=2, stride=2):\n",
+    "    # x: (N, C, H, W)\n",
+    "    N, C, H, W = x.shape\n",
+    "    k, s = kernel_size, stride\n",
+    "\n",
+    "    H_out = (H - k) // s + 1\n",
+    "    W_out = (W - k) // s + 1\n",
+    "\n",
+    "    out = np.zeros((N, C, H_out, W_out), dtype=np.float64)\n",
+    "    argmax = np.zeros((N, C, H_out, W_out), dtype=np.int64)   # flat index inside each window\n",
+    "\n",
+    "    for i in range(H_out):\n",
+    "        for j in range(W_out):\n",
+    "            window = x[:, :, i * s:i * s + k, j * s:j * s + k].reshape(N, C, -1)\n",
+    "            idx = window.argmax(axis=2)\n",
+    "            argmax[:, :, i, j] = idx\n",
+    "            out[:, :, i, j] = np.take_along_axis(window, idx[:, :, None], axis=2)[:, :, 0]\n",
+    "\n",
+    "    n_idx, c_idx = np.indices((N, C))\n",
+    "\n",
+    "    def backward(dout):\n",
+    "        # Pure routing: each upstream value lands on its window's winner, everything else stays 0\n",
+    "        dx = np.zeros((N, C, H, W), dtype=np.float64)\n",
+    "        for i in range(H_out):\n",
+    "            for j in range(W_out):\n",
+    "                di, dj = np.divmod(argmax[:, :, i, j], k)      # unflatten the window offset\n",
+    "                np.add.at(dx, (n_idx, c_idx, i * s + di, j * s + dj), dout[:, :, i, j])\n",
+    "        return dx\n",
+    "\n",
+    "    return out, backward"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "out, backward = maxpool2d(x, kernel_size=2, stride=2)\n",
+    "print(\"out shape:\", out.shape)\n",
+    "print(\"dx  shape:\", backward(np.ones_like(out)).shape)\n",
+    "\n",
+    "tiny = np.array([[[[1.0, 2.0], [3.0, 9.0]]]])\n",
+    "o, bwd = maxpool2d(tiny, 2, 2)\n",
+    "print(\"max      :\", o.ravel())\n",
+    "print(\"routed dx:\", bwd(np.array([[[[5.0]]]])).ravel(), \"(expect [0 0 0 5])\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_judge import check\n",
+    "check(\"numpy_maxpool2d\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/37_flow_matching.ipynb
+++ b/templates/37_flow_matching.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: Flow Matching Loss (Rectified Flow)\n",
+    "\n",
+    "Implement the **Flow Matching / Rectified Flow** training objective.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Diffusion models learn to reverse a *curved*, hand-designed noising SDE. Flow Matching asks a simpler\n",
+    "question: pick **any** path that connects noise to data, and just regress the **velocity** that moves\n",
+    "a point along it.\n",
+    "\n",
+    "Rectified Flow picks the simplest path of all — a **straight line**:\n",
+    "\n",
+    "$$x_t = (1-t)\\,x_0 + t\\,x_1, \\qquad t \\in [0, 1]$$\n",
+    "\n",
+    "with $x_0 \\sim \\mathcal{N}(0, I)$ (noise) and $x_1$ a real data sample. Differentiate the path:\n",
+    "\n",
+    "$$u_t = \\frac{d x_t}{d t} = x_1 - x_0$$\n",
+    "\n",
+    "The target velocity is **constant in $t$** — the whole schedule/SNR machinery of DDPM disappears. Train\n",
+    "a network $v_\\theta$ to regress it:\n",
+    "\n",
+    "$$\\mathcal{L} = \\mathbb{E}_{t \\sim U[0,1],\\, x_0,\\, x_1} \\left\\| v_\\theta(x_t, t) - (x_1 - x_0) \\right\\|^2$$\n",
+    "\n",
+    "At sampling time you just integrate the ODE $\\dot{x} = v_\\theta(x, t)$ from $t{=}0$ to $t{=}1$. Because\n",
+    "the learned field is nearly straight, a handful of Euler steps is enough — this is why SD3, Flux and\n",
+    "friends moved to it.\n",
+    "\n",
+    "**The one bug everyone hits:** `t` has shape `(B,)` while `x` has shape `(B, C, H, W)`. Multiply them\n",
+    "directly and broadcasting silently mixes samples. Reshape `t` to `(B, 1, 1, 1)` first.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def flow_matching_loss(model, x0, x1, t):\n",
+    "    # model: callable (x_t, t) -> predicted velocity, same shape as x\n",
+    "    # x0:    noise sample,  shape (B, ...)\n",
+    "    # x1:    data sample,   shape (B, ...)\n",
+    "    # t:     timesteps in [0, 1], shape (B,)\n",
+    "    # returns: scalar MSE loss\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Do **NOT** use any built-in flow-matching helper\n",
+    "- `t=0` must give pure noise, `t=1` must give pure data\n",
+    "- The loss must be differentiable w.r.t. the model parameters\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "x0 = torch.randn(8, 4)        # noise\n",
+    "x1 = torch.randn(8, 4)        # data\n",
+    "t  = torch.rand(8)            # per-sample timestep\n",
+    "loss = flow_matching_loss(lambda x, t: torch.zeros_like(x), x0, x1, t)\n",
+    "# -> equals ((x1 - x0) ** 2).mean(), because the model predicts zero velocity\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def flow_matching_loss(model, x0, x1, t):\n",
+    "    # x0: noise (B, ...)   x1: data (B, ...)   t: (B,) in [0, 1]\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "x0 = torch.randn(8, 4)\n",
+    "x1 = torch.randn(8, 4)\n",
+    "t = torch.rand(8)\n",
+    "\n",
+    "print(\"zero-velocity model :\", flow_matching_loss(lambda x, tt: torch.zeros_like(x), x0, x1, t).item())\n",
+    "print(\"expected            :\", ((x1 - x0) ** 2).mean().item())\n",
+    "print(\"perfect model       :\", flow_matching_loss(lambda x, tt: x1 - x0, x0, x1, t).item(), \"(should be ~0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"flow_matching\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/38_dmd2.ipynb
+++ b/templates/38_dmd2.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: DMD2 Distribution Matching Loss\n",
+    "\n",
+    "Implement the core loss of **DMD2** (Improved Distribution Matching Distillation), the objective that\n",
+    "distills a 50-step diffusion teacher into a **one-step** generator.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "We want a one-step generator $G$ whose output distribution $p_\\text{fake}$ matches the teacher's\n",
+    "$p_\\text{real}$. Minimise the reverse KL:\n",
+    "\n",
+    "$$\\mathcal{L} = D_{KL}(p_\\text{fake} \\,\\|\\, p_\\text{real})$$\n",
+    "\n",
+    "You cannot evaluate either density — but you never need to. Its gradient w.r.t. a *generated sample*\n",
+    "is exactly the **difference of two scores**:\n",
+    "\n",
+    "$$\\nabla_x D_{KL} = \\underbrace{\\nabla_x \\log p_\\text{fake}(x)}_{s_\\text{fake}} - \\underbrace{\\nabla_x \\log p_\\text{real}(x)}_{s_\\text{real}}$$\n",
+    "\n",
+    "and diffusion models *are* score estimators. So you keep two denoisers around:\n",
+    "\n",
+    "| | what it is | how it is trained |\n",
+    "|---|---|---|\n",
+    "| $\\mu_\\text{real}$ | the frozen teacher | not trained |\n",
+    "| $\\mu_\\text{fake}$ | an online copy | ordinary diffusion loss on the generator's own outputs |\n",
+    "\n",
+    "In $x_0$-prediction space the score difference is proportional to\n",
+    "$(\\mu_\\text{fake} - \\mu_\\text{real})$, giving the **distribution matching gradient**:\n",
+    "\n",
+    "$$\\text{grad} = \\frac{\\mu_\\text{fake}(x) - \\mu_\\text{real}(x)}{\\underbrace{\\text{mean}\\,|\\mu_\\text{real}(x) - x|}_{\\text{per-sample normalizer}}}$$\n",
+    "\n",
+    "The normalizer makes the update scale-free, which is what lets a single learning rate work across\n",
+    "noise levels and resolutions.\n",
+    "\n",
+    "**The trick that makes it trainable:** autograd wants a *loss*, not a gradient. So build a surrogate\n",
+    "whose derivative is the gradient you already computed:\n",
+    "\n",
+    "$$\\mathcal{L} = \\tfrac{1}{2}\\,\\text{MSE}\\big(x,\\ \\text{stopgrad}(x - \\text{grad})\\big) \\quad\\Longrightarrow\\quad \\frac{\\partial \\mathcal{L}}{\\partial x} = \\frac{\\text{grad}}{N}$$\n",
+    "\n",
+    "The `stopgrad` matters: the teacher is frozen, and the fake denoiser is trained by its *own* loss, so\n",
+    "no gradient may flow into either prediction from here.\n",
+    "\n",
+    "**What \"2\" adds to DMD:** (1) drops DMD's expensive regression loss and the teacher-ODE dataset it\n",
+    "required, (2) a **two time-scale update** — refresh $\\mu_\\text{fake}$ several times per generator\n",
+    "step so the fake score never goes stale, (3) an extra **GAN loss** on real data, which lets the\n",
+    "student *surpass* its teacher, (4) a multi-step (4-step) generator with backward simulation.\n",
+    "This exercise implements the piece all of that is built on.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def dmd_loss(x_gen, pred_real, pred_fake, eps=1e-8):\n",
+    "    # x_gen:     generator output, shape (B, ...), requires grad\n",
+    "    # pred_real: frozen teacher's x0-prediction, same shape\n",
+    "    # pred_fake: online fake-score model's x0-prediction, same shape\n",
+    "    # returns: scalar loss whose gradient w.r.t. x_gen is grad / numel\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- The normalizer is computed **per sample** (mean over every non-batch dim, `keepdim=True`)\n",
+    "- The regression target must be **detached** — no gradient into `pred_real` / `pred_fake`\n",
+    "- Guard the division with `eps` and `torch.nan_to_num`\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "x_gen     = torch.randn(4, 3, 8, 8, requires_grad=True)\n",
+    "pred_real = torch.randn(4, 3, 8, 8)\n",
+    "pred_fake = torch.randn(4, 3, 8, 8)\n",
+    "loss = dmd_loss(x_gen, pred_real, pred_fake)\n",
+    "loss.backward()\n",
+    "# x_gen.grad == (pred_fake - pred_real) / normalizer / x_gen.numel()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def dmd_loss(x_gen, pred_real, pred_fake, eps=1e-8):\n",
+    "    # x_gen: generator output (B, ...)\n",
+    "    # pred_real / pred_fake: x0-predictions of the frozen teacher / online fake score model\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "x = torch.randn(4, 3, 8, 8, requires_grad=True)\n",
+    "pred_real = torch.randn(4, 3, 8, 8)\n",
+    "pred_fake = torch.randn(4, 3, 8, 8)\n",
+    "\n",
+    "loss = dmd_loss(x, pred_real, pred_fake)\n",
+    "loss.backward()\n",
+    "print(\"loss           :\", loss.item())\n",
+    "print(\"grad shape     :\", tuple(x.grad.shape))\n",
+    "\n",
+    "normalizer = (pred_real - x.detach()).abs().mean(dim=(1, 2, 3), keepdim=True)\n",
+    "expected = (pred_fake - pred_real) / (normalizer + 1e-8) / x.numel()\n",
+    "print(\"matches theory :\", torch.allclose(x.grad, expected, atol=1e-6))\n",
+    "print(\"zero when equal:\", dmd_loss(x, pred_real, pred_real).item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"dmd2\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/39_cfg.ipynb
+++ b/templates/39_cfg.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: Classifier-Free Guidance\n",
+    "\n",
+    "Implement **classifier-free guidance** (CFG), the single knob behind \"prompt adherence\" in every\n",
+    "modern text-to-image and text-to-video model.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Guided diffusion originally needed a separate classifier $p(c \\mid x)$ to push samples toward a\n",
+    "condition. CFG removes it: train **one** network with the condition randomly dropped (say 10% of the\n",
+    "time replaced by a null token $\\varnothing$), so it learns the conditional *and* the unconditional\n",
+    "score at once. Then at sampling time, use Bayes:\n",
+    "\n",
+    "$$\\nabla_x \\log p(x \\mid c) + w'\\,\\nabla_x \\log \\frac{p(x \\mid c)}{p(x)}$$\n",
+    "\n",
+    "which in $\\epsilon$-space is just a linear extrapolation away from the unconditional prediction:\n",
+    "\n",
+    "$$\\hat{\\epsilon} = \\epsilon_\\varnothing + w \\cdot (\\epsilon_c - \\epsilon_\\varnothing)$$\n",
+    "\n",
+    "| $w$ | meaning |\n",
+    "|:---:|---|\n",
+    "| 0 | ignore the condition entirely |\n",
+    "| 1 | plain conditional sampling — **no guidance** |\n",
+    "| 5–15 | typical; sharper, more prompt-faithful, less diverse |\n",
+    "\n",
+    "Note it costs **2× compute**: every step evaluates the model twice (usually as one batch of size 2B).\n",
+    "\n",
+    "**The catch — and the rescale fix.** Extrapolating with $w \\gg 1$ inflates the variance of\n",
+    "$\\hat{\\epsilon}$, which over-saturates and blows out images. *Common Diffusion Noise Schedules and\n",
+    "Sample Steps are Flawed* fixes it by renormalising back to the conditional branch's statistics and\n",
+    "blending:\n",
+    "\n",
+    "$$\\hat{\\epsilon}_\\text{rescaled} = \\hat{\\epsilon}\\cdot\\frac{\\sigma(\\epsilon_c)}{\\sigma(\\hat{\\epsilon})}, \\qquad \\hat{\\epsilon}_\\text{final} = \\phi\\,\\hat{\\epsilon}_\\text{rescaled} + (1-\\phi)\\,\\hat{\\epsilon}$$\n",
+    "\n",
+    "Standard deviations are **per sample** (over all non-batch dims) — batch elements must never mix.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def classifier_free_guidance(eps_uncond, eps_cond, guidance_scale, rescale=0.0):\n",
+    "    # eps_uncond: model output for the null condition, shape (B, ...)\n",
+    "    # eps_cond:   model output for the real condition, same shape\n",
+    "    # guidance_scale: w  (1.0 == no guidance)\n",
+    "    # rescale: phi in [0, 1]; 0.0 disables the std-rescale trick\n",
+    "    # returns: guided prediction, same shape\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Use `torch.std` with its default (unbiased) correction, computed per sample with `keepdim=True`\n",
+    "- `guidance_scale=1.0` must return `eps_cond` **exactly**; `0.0` must return `eps_uncond`\n",
+    "- `rescale=0.0` must be a no-op\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "eps_u = torch.randn(4, 3, 8, 8)\n",
+    "eps_c = torch.randn(4, 3, 8, 8)\n",
+    "out = classifier_free_guidance(eps_u, eps_c, 7.5)\n",
+    "# -> eps_u + 7.5 * (eps_c - eps_u)\n",
+    "out = classifier_free_guidance(eps_u, eps_c, 7.5, rescale=1.0)\n",
+    "# -> same direction, but each sample's std matches eps_c's std\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def classifier_free_guidance(eps_uncond, eps_cond, guidance_scale, rescale=0.0):\n",
+    "    # eps_uncond / eps_cond: (B, ...)   guidance_scale: w   rescale: phi in [0, 1]\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "eps_u = torch.randn(4, 3, 8, 8)\n",
+    "eps_c = torch.randn(4, 3, 8, 8)\n",
+    "\n",
+    "out = classifier_free_guidance(eps_u, eps_c, 7.5)\n",
+    "print(\"w=7.5 matches formula :\", torch.allclose(out, eps_u + 7.5 * (eps_c - eps_u), atol=1e-6))\n",
+    "print(\"w=1.0 is conditional  :\", torch.allclose(classifier_free_guidance(eps_u, eps_c, 1.0), eps_c, atol=1e-6))\n",
+    "print(\"std blow-up (w=7.5)   :\", out.std(dim=(1, 2, 3)).mean().item(), \"vs cond\", eps_c.std(dim=(1, 2, 3)).mean().item())\n",
+    "\n",
+    "out_r = classifier_free_guidance(eps_u, eps_c, 7.5, rescale=1.0)\n",
+    "print(\"after rescale=1.0     :\", out_r.std(dim=(1, 2, 3)).mean().item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"cfg\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/40_numpy_mlp_forward.ipynb
+++ b/templates/40_numpy_mlp_forward.ipynb
@@ -1,0 +1,125 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: MLP Forward Pass (NumPy)\n",
+    "\n",
+    "Implement the forward pass of an **L-layer ReLU MLP** using only NumPy.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Every neural network is a chain of two ingredients: an **affine map** and a **nonlinearity**.\n",
+    "\n",
+    "$$A^{(0)} = X, \\qquad Z^{(l)} = A^{(l-1)} W^{(l)} + b^{(l)}, \\qquad A^{(l)} = \\mathrm{ReLU}\\!\\left(Z^{(l)}\\right)$$\n",
+    "\n",
+    "Two details carry all the meaning:\n",
+    "\n",
+    "1. **The last layer stays linear.** It emits *logits* — unbounded real scores. Squashing them with\n",
+    "   ReLU would clip half the score range and destroy the softmax that follows.\n",
+    "2. **Without the nonlinearity the depth is fake.** $XW_1W_2 = X(W_1W_2)$ — a stack of affine maps is\n",
+    "   just one affine map. ReLU is the cheapest thing that breaks that collapse.\n",
+    "\n",
+    "Shapes are the whole game. Here $W$ has shape `(in, out)` and rows of $X$ are samples, so it is\n",
+    "`A @ W` (not `A @ W.T` like `nn.Linear`). The bias `(out,)` broadcasts down every row.\n",
+    "\n",
+    "Keep this function clean — the [backprop problem](#) reuses exactly this forward pass, plus a cache.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def mlp_forward(X, params):\n",
+    "    # X:      (N, d_in) input batch\n",
+    "    # params: list of (W, b) with W: (d_in, d_out), b: (d_out,)\n",
+    "    # returns: logits (N, d_out) — NO activation on the last layer\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch\n",
+    "- ReLU on hidden layers only; the final layer stays linear\n",
+    "- Do not modify `X` or `params` in place\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "X = np.random.randn(5, 4)\n",
+    "params = [(np.random.randn(4, 6), np.zeros(6)),\n",
+    "          (np.random.randn(6, 3), np.zeros(3))]\n",
+    "mlp_forward(X, params).shape  ->  (5, 3)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def mlp_forward(X, params):\n",
+    "    # X: (N, d_in);  params: list of (W, b), W: (in, out), b: (out,)\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "np.random.seed(0)\n",
+    "X = np.random.randn(5, 4)\n",
+    "params = [(np.random.randn(4, 6), np.random.randn(6)),\n",
+    "          (np.random.randn(6, 3), np.random.randn(3))]\n",
+    "\n",
+    "out = mlp_forward(X, params)\n",
+    "print(\"output shape:\", out.shape)\n",
+    "print(\"logits can be negative:\", (out < 0).any())\n",
+    "print(\"one layer == affine:\", np.allclose(mlp_forward(X, [params[0]]), X @ params[0][0] + params[0][1]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_mlp_forward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/41_numpy_softmax_ce.ipynb
+++ b/templates/41_numpy_softmax_ce.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: Softmax Cross-Entropy + Gradient (NumPy)\n",
+    "\n",
+    "Implement softmax cross-entropy **and its gradient** in one pass, using only NumPy.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Softmax turns logits into probabilities, cross-entropy scores them:\n",
+    "\n",
+    "$$p_{ij} = \\frac{e^{z_{ij}}}{\\sum_k e^{z_{ik}}}, \\qquad \\mathcal{L} = -\\frac{1}{N}\\sum_i \\log p_{i, y_i}$$\n",
+    "\n",
+    "**Why they are always fused.** Softmax alone has a full $C \\times C$ Jacobian\n",
+    "$\\partial p_i / \\partial z_j = p_i(\\delta_{ij} - p_j)$ — ugly and expensive. Compose it with\n",
+    "cross-entropy and almost everything cancels, leaving the most elegant gradient in deep learning:\n",
+    "\n",
+    "$$\\frac{\\partial \\mathcal{L}}{\\partial z_{ij}} = \\frac{p_{ij} - \\mathbb{1}[j = y_i]}{N}$$\n",
+    "\n",
+    "*\"predicted minus actual\"* — that is the entire backward pass. This is why every framework ships\n",
+    "`cross_entropy(logits, labels)` instead of `nll_loss(softmax(logits))`: it is faster **and** it never\n",
+    "computes `log(0)`.\n",
+    "\n",
+    "**Numerical stability.** `exp(1000)` overflows to `inf` in float64. But softmax is shift-invariant —\n",
+    "$\\mathrm{softmax}(z) = \\mathrm{softmax}(z - c)$ for any $c$ — so subtract the row max first. Then the\n",
+    "largest exponent is exactly $e^0 = 1$ and overflow is impossible.\n",
+    "\n",
+    "Two sanity checks worth remembering: uniform logits over $C$ classes give $\\log C$ (that is your\n",
+    "\"random guessing\" baseline — 2.30 for 10 classes), and every row of the gradient sums to zero,\n",
+    "because probabilities sum to one.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def softmax_cross_entropy(logits, labels):\n",
+    "    # logits: (N, C) raw scores\n",
+    "    # labels: (N,) integer class indices\n",
+    "    # returns: (loss, dlogits) — scalar mean loss and its (N, C) gradient\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch\n",
+    "- Subtract the row max before `exp` (must survive logits of ±1000)\n",
+    "- Average the loss over the batch, and divide the gradient by `N` to match\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "logits = np.zeros((4, 10))\n",
+    "loss, dlogits = softmax_cross_entropy(logits, np.array([0, 3, 7, 9]))\n",
+    "# loss == log(10) == 2.302...,  dlogits.sum() == 0\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def softmax_cross_entropy(logits, labels):\n",
+    "    # logits: (N, C);  labels: (N,) int\n",
+    "    # returns (loss, dlogits)\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "np.random.seed(0)\n",
+    "logits = np.random.randn(6, 4)\n",
+    "labels = np.array([0, 1, 2, 3, 0, 1])\n",
+    "\n",
+    "loss, dlogits = softmax_cross_entropy(logits, labels)\n",
+    "print(\"loss        :\", float(loss))\n",
+    "print(\"dlogits     :\", dlogits.shape)\n",
+    "print(\"rows sum ~0 :\", np.allclose(dlogits.sum(axis=1), 0))\n",
+    "\n",
+    "uniform_loss, _ = softmax_cross_entropy(np.zeros((4, 10)), np.array([0, 3, 7, 9]))\n",
+    "print(\"uniform loss:\", float(uniform_loss), \"== log(10) =\", np.log(10))\n",
+    "\n",
+    "big, _ = softmax_cross_entropy(np.array([[1000.0, 1001.0, 999.0]]), np.array([1]))\n",
+    "print(\"stable      :\", np.isfinite(big))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_softmax_ce\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/42_numpy_mlp_backward.ipynb
+++ b/templates/42_numpy_mlp_backward.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: MLP Backpropagation (NumPy)\n",
+    "\n",
+    "Write the **complete forward + backward pass** of an L-layer ReLU MLP with softmax cross-entropy —\n",
+    "no autograd, only NumPy. This is the exercise that makes `loss.backward()` stop being magic.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Backprop is the chain rule executed in **reverse topological order**, reusing the values the forward\n",
+    "pass already computed. Two invariants make it hard to get wrong:\n",
+    "\n",
+    "1. **Cache during the forward pass.** Every layer needs its input $A^{(l-1)}$ and its pre-activation\n",
+    "   $Z^{(l)}$ later. Recomputing them is the classic beginner's mistake — that is the memory/compute\n",
+    "   trade-off behind gradient checkpointing.\n",
+    "2. **Every gradient has the shape of the thing it differentiates.** `dW.shape == W.shape` always. If\n",
+    "   your shapes line up, your transposes are almost certainly right.\n",
+    "\n",
+    "Seed the backward pass with the fused softmax-CE gradient, then walk backwards:\n",
+    "\n",
+    "$$dZ^{(L)} = \\frac{P - \\mathbb{1}_y}{N}$$\n",
+    "\n",
+    "$$dW^{(l)} = A^{(l-1)\\top} dZ^{(l)}, \\qquad db^{(l)} = \\textstyle\\sum_i dZ^{(l)}_i, \\qquad dA^{(l-1)} = dZ^{(l)} W^{(l)\\top}$$\n",
+    "\n",
+    "$$dZ^{(l-1)} = dA^{(l-1)} \\odot \\mathbb{1}\\!\\left[Z^{(l-1)} > 0\\right]$$\n",
+    "\n",
+    "Read the three rules off the forward pass: `Z = A @ W + b` is a **product** (each factor's gradient\n",
+    "is the upstream gradient times the *other* factor), a **broadcast** (broadcasting forward ⇒ summing\n",
+    "backward, hence `db = dZ.sum(axis=0)`), and ReLU is a **gate** (it multiplies by a 0/1 mask forward,\n",
+    "so it multiplies by the same mask backward — a dead unit gets exactly zero gradient forever, which is\n",
+    "the \"dying ReLU\" problem in one line of algebra).\n",
+    "\n",
+    "**Always gradient-check.** Compare against $(\\mathcal{L}(w+\\epsilon) - \\mathcal{L}(w-\\epsilon)) / 2\\epsilon$;\n",
+    "with $\\epsilon = 10^{-6}$ in float64 you should match to ~1e-8.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def mlp_loss_and_grads(X, labels, params):\n",
+    "    # X:      (N, d_in)\n",
+    "    # labels: (N,) integer class indices\n",
+    "    # params: list of (W, b) with W: (in, out), b: (out,)\n",
+    "    # returns: (loss, grads) where grads is a list of (dW, db) matching params\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch, no autograd\n",
+    "- ReLU on hidden layers, linear logits, softmax cross-entropy loss averaged over the batch\n",
+    "- `dW.shape == W.shape` and `db.shape == b.shape` for every layer\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "loss, grads = mlp_loss_and_grads(X, labels, params)\n",
+    "for (W, b), (dW, db) in zip(params, grads):   # one SGD step\n",
+    "    W -= lr * dW\n",
+    "    b -= lr * db\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def mlp_loss_and_grads(X, labels, params):\n",
+    "    # X: (N, d_in);  labels: (N,) int;  params: list of (W, b)\n",
+    "    # returns (loss, [(dW, db), ...])\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation — train on a toy linearly-separable problem\n",
+    "np.random.seed(0)\n",
+    "X = np.random.randn(40, 4)\n",
+    "labels = (X[:, 0] + X[:, 1] > 0).astype(np.int64)\n",
+    "params = [(np.random.randn(4, 16) * 0.5, np.zeros(16)),\n",
+    "          (np.random.randn(16, 2) * 0.5, np.zeros(2))]\n",
+    "\n",
+    "for step in range(300):\n",
+    "    loss, grads = mlp_loss_and_grads(X, labels, params)\n",
+    "    if step % 100 == 0:\n",
+    "        print(f\"step {step:3d}  loss {float(loss):.4f}\")\n",
+    "    for (W, b), (dW, db) in zip(params, grads):\n",
+    "        W -= 0.1 * dW\n",
+    "        b -= 0.1 * db\n",
+    "\n",
+    "print(f\"final     loss {float(loss):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_mlp_backward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/43_numpy_conv2d.ipynb
+++ b/templates/43_numpy_conv2d.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: Conv2D Forward (NumPy)\n",
+    "\n",
+    "Implement a 2-D convolution forward pass over `NCHW` tensors, using only NumPy.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "A convolution is a linear layer with two constraints bolted on: **local connectivity** (each output\n",
+    "sees only a $K \\times K$ patch) and **weight sharing** (the same kernel slides over every position).\n",
+    "That is what buys translation equivariance and cuts parameters from $O(HW \\cdot H'W')$ to $O(K^2)$\n",
+    "per channel pair.\n",
+    "\n",
+    "$$\\text{out}[n, f, i, j] = b_f + \\sum_{c}\\sum_{u=0}^{K_H-1}\\sum_{v=0}^{K_W-1} x[n,\\, c,\\, is+u-p,\\, js+v-p]\\; w[f,\\, c,\\, u,\\, v]$$\n",
+    "\n",
+    "Read the shapes as a contract: `x` is `(N, C, H, W)`, `w` is `(F, C, KH, KW)`, `b` is `(F,)`. Each\n",
+    "output channel $f$ is one filter that spans **all** input channels — a convolution is only spatially\n",
+    "local, never channel-local.\n",
+    "\n",
+    "$$H_\\text{out} = \\left\\lfloor \\frac{H + 2p - K_H}{s} \\right\\rfloor + 1$$\n",
+    "\n",
+    "Three things worth internalising:\n",
+    "\n",
+    "- **It is cross-correlation, not convolution.** No kernel flipping. The math community's flip does not\n",
+    "  survive into deep learning because the kernel is learned — a flipped kernel is just as learnable.\n",
+    "- **Padding preserves resolution.** `p = (K-1)/2` with `s = 1` keeps `H_out == H`, which is why odd\n",
+    "  kernels (3, 5, 7) dominate.\n",
+    "- **The loop you write is not the loop that runs.** Real implementations use *im2col*: flatten every\n",
+    "  patch into a row, and the whole convolution becomes one big GEMM. Loop over the *output positions*\n",
+    "  (there are few) and vectorise over batch, channels and filters — never loop over N or C.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def conv2d_forward(x, w, b, stride=1, padding=0):\n",
+    "    # x: (N, C, H, W)   w: (F, C, KH, KW)   b: (F,)\n",
+    "    # returns: (N, F, H_out, W_out)\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch, no `scipy.signal`\n",
+    "- Zero padding on the spatial dims only\n",
+    "- Cross-correlation (do **not** flip the kernel)\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "w = np.random.randn(4, 3, 3, 3)\n",
+    "b = np.random.randn(4)\n",
+    "conv2d_forward(x, w, b, stride=1, padding=0).shape  ->  (2, 4, 6, 6)\n",
+    "conv2d_forward(x, w, b, stride=2, padding=1).shape  ->  (2, 4, 4, 4)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def conv2d_forward(x, w, b, stride=1, padding=0):\n",
+    "    # x: (N, C, H, W);  w: (F, C, KH, KW);  b: (F,)\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "w = np.random.randn(4, 3, 3, 3)\n",
+    "b = np.random.randn(4)\n",
+    "\n",
+    "print(\"stride=1 padding=0:\", conv2d_forward(x, w, b, 1, 0).shape, \"(expect (2, 4, 6, 6))\")\n",
+    "print(\"stride=1 padding=1:\", conv2d_forward(x, w, b, 1, 1).shape, \"(expect (2, 4, 8, 8) — resolution preserved)\")\n",
+    "print(\"stride=2 padding=1:\", conv2d_forward(x, w, b, 2, 1).shape, \"(expect (2, 4, 4, 4))\")\n",
+    "\n",
+    "# A center-tap kernel must reproduce the input\n",
+    "ident = np.zeros((1, 1, 3, 3)); ident[0, 0, 1, 1] = 1.0\n",
+    "one = np.random.randn(1, 1, 5, 5)\n",
+    "print(\"identity kernel   :\", np.allclose(conv2d_forward(one, ident, np.zeros(1), 1, 1), one))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_conv2d\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/44_numpy_conv2d_backward.ipynb
+++ b/templates/44_numpy_conv2d_backward.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔴 Hard: Conv2D Backward (NumPy)\n",
+    "\n",
+    "Given the upstream gradient `dout`, compute `dx`, `dw` and `db` for a 2-D convolution — pure NumPy.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Convolution is linear in **both** `x` and `w`, so its backward pass is two contractions of the same\n",
+    "sliding window — the exact mirror of the forward loop.\n",
+    "\n",
+    "For one output position $(i, j)$, write $d = \\text{dout}[:, :, i, j]$ with shape $(N, F)$ and\n",
+    "$\\text{patch} = x_\\text{pad}[:, :, is{:}is{+}K_H,\\ js{:}js{+}K_W]$ with shape $(N, C, K_H, K_W)$:\n",
+    "\n",
+    "$$db_f = \\sum_{n, i, j} \\text{dout}[n, f, i, j] \\qquad\\text{— the bias is broadcast, so it sums back}$$\n",
+    "\n",
+    "$$dw \\mathrel{+}= \\sum_n d[n, :] \\otimes \\text{patch}[n] \\qquad dx_\\text{pad}[\\text{window}] \\mathrel{+}= \\sum_f d[:, f]\\, w[f]$$\n",
+    "\n",
+    "The single idea that makes it click: **weight sharing forward ⇒ gradient accumulation backward.**\n",
+    "A weight used at 64 positions collects gradient from all 64 — that is why `dw` is a *sum over the\n",
+    "whole feature map*, and why `+=` (never `=`) is mandatory when writing into `dx`. With `stride <\n",
+    "kernel_size` the windows overlap, so an interior pixel feeds several outputs and must collect all of\n",
+    "their gradients.\n",
+    "\n",
+    "Two loose ends that are pure bookkeeping but where everyone loses an hour:\n",
+    "\n",
+    "- Accumulate into the **padded** `dx`, then crop the border off at the very end — `dx` must come back\n",
+    "  with the shape of `x`, not of `x_pad`.\n",
+    "- `dw` sums over the batch too. Its shape is `(F, C, KH, KW)` no matter how large `N` is.\n",
+    "\n",
+    "Fun fact for later: $dx$ is itself a convolution of `dout` with the *flipped* kernel — a\n",
+    "\"transposed convolution\", the same op that upsamples in decoders and GANs.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def conv2d_backward(dout, x, w, stride=1, padding=0):\n",
+    "    # dout: (N, F, H_out, W_out) upstream gradient\n",
+    "    # x:    (N, C, H, W)   w: (F, C, KH, KW)\n",
+    "    # returns: (dx, dw, db) with shapes of x, w, (F,)\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch, no autograd\n",
+    "- Accumulate with `+=`; overlapping windows must add up\n",
+    "- Crop the padding off `dx` before returning\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "dx, dw, db = conv2d_backward(dout, x, w, stride=1, padding=1)\n",
+    "# db == dout.sum(axis=(0, 2, 3))\n",
+    "# matches tx.grad / tw.grad from torch autograd\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def conv2d_backward(dout, x, w, stride=1, padding=0):\n",
+    "    # dout: (N, F, H_out, W_out);  x: (N, C, H, W);  w: (F, C, KH, KW)\n",
+    "    # returns (dx, dw, db)\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "w = np.random.randn(4, 3, 3, 3)\n",
+    "dout = np.random.randn(2, 4, 6, 6)\n",
+    "\n",
+    "dx, dw, db = conv2d_backward(dout, x, w, stride=1, padding=0)\n",
+    "print(\"dx:\", dx.shape, \" dw:\", dw.shape, \" db:\", db.shape)\n",
+    "print(\"db == dout.sum:\", np.allclose(db, dout.sum(axis=(0, 2, 3))))\n",
+    "\n",
+    "# Overlapping windows: an interior pixel is covered by 4 windows of a 2x2 kernel at stride 1\n",
+    "xs = np.zeros((1, 1, 4, 4))\n",
+    "ws = np.ones((1, 1, 2, 2))\n",
+    "dxs, _, _ = conv2d_backward(np.ones((1, 1, 3, 3)), xs, ws, stride=1, padding=0)\n",
+    "print(\"corner pixel  :\", dxs[0, 0, 0, 0], \"(expect 1.0)\")\n",
+    "print(\"interior pixel:\", dxs[0, 0, 1, 1], \"(expect 4.0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_conv2d_backward\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/templates/45_numpy_maxpool2d.ipynb
+++ b/templates/45_numpy_maxpool2d.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🟡 Medium: MaxPool2D Forward & Backward (NumPy)\n",
+    "\n",
+    "Implement max pooling with **both** directions, returning the forward output and a `backward` closure.\n",
+    "\n",
+    "### Core Idea\n",
+    "\n",
+    "Max pooling downsamples by keeping only the strongest activation in each window. It has **no\n",
+    "parameters** — so the only thing its backward pass needs is *where each maximum came from*:\n",
+    "\n",
+    "$$\\text{out}[n,c,i,j] = \\max_{0 \\le u,v < K} x[n,\\,c,\\,is{+}u,\\,js{+}v]$$\n",
+    "\n",
+    "$$\\frac{\\partial \\text{out}}{\\partial x[n,c,h,w]} = \\begin{cases} 1 & (h, w) \\text{ was the argmax} \\\\ 0 & \\text{otherwise}\\end{cases}$$\n",
+    "\n",
+    "Max is a **router**, not a mixer: the gradient flows through the winner untouched and every loser\n",
+    "gets exactly zero. (Contrast average pooling, which splits the gradient evenly across $K^2$ inputs —\n",
+    "and note this \"winner takes all\" routing is exactly what ReLU and MoE top-k gating do too.)\n",
+    "\n",
+    "So the forward pass must **record the argmax**; without it the backward pass would have to re-scan\n",
+    "the input. Store the flat index inside each window and recover the offsets with `divmod(idx, K)`.\n",
+    "\n",
+    "**Why return a closure.** `backward` captures the argmax cache in its scope — the same\n",
+    "`(value, vjp_fn)` pattern that JAX and PyTorch's `autograd.Function` use, and a compact way to make\n",
+    "the forward/backward pairing explicit:\n",
+    "\n",
+    "```python\n",
+    "out, backward = maxpool2d(x, 2, 2)\n",
+    "dx = backward(dout)\n",
+    "```\n",
+    "\n",
+    "With `stride < kernel_size` windows overlap and one pixel can win several of them, so accumulate with\n",
+    "`+=`. And note pooling is only *approximately* translation-invariant — shifting the input by one\n",
+    "pixel can flip which element wins, which is exactly why strided convolutions have largely replaced it.\n",
+    "\n",
+    "### Signature\n",
+    "```python\n",
+    "def maxpool2d(x, kernel_size=2, stride=2):\n",
+    "    # x: (N, C, H, W)\n",
+    "    # returns: (out, backward) where\n",
+    "    #   out:      (N, C, H_out, W_out)\n",
+    "    #   backward: callable(dout) -> dx with the shape of x\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "### Rules\n",
+    "- Pure **NumPy** — no PyTorch\n",
+    "- The forward pass must cache the argmax; `backward` may not re-derive it from `out`\n",
+    "- Overlapping windows accumulate with `+=`\n",
+    "\n",
+    "### Example\n",
+    "```\n",
+    "x = np.array([[[[1., 2.], [3., 9.]]]])\n",
+    "out, backward = maxpool2d(x, 2, 2)      # out == 9.0\n",
+    "backward(np.array([[[[5.]]]]))          # -> [[[[0., 0.], [0., 5.]]]]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✏️ YOUR IMPLEMENTATION HERE\n",
+    "\n",
+    "def maxpool2d(x, kernel_size=2, stride=2):\n",
+    "    # x: (N, C, H, W)\n",
+    "    # returns (out, backward) where backward(dout) -> dx\n",
+    "    pass  # Replace this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧪 Test your implementation\n",
+    "np.random.seed(0)\n",
+    "x = np.random.randn(2, 3, 8, 8)\n",
+    "out, backward = maxpool2d(x, kernel_size=2, stride=2)\n",
+    "print(\"out shape:\", out.shape, \"(expect (2, 3, 4, 4))\")\n",
+    "print(\"dx  shape:\", backward(np.ones_like(out)).shape, \"(expect (2, 3, 8, 8))\")\n",
+    "\n",
+    "# Gradient routing: only the winner gets it\n",
+    "tiny = np.array([[[[1.0, 2.0], [3.0, 9.0]]]])\n",
+    "o, bwd = maxpool2d(tiny, 2, 2)\n",
+    "print(\"max      :\", o.ravel())\n",
+    "print(\"routed dx:\", bwd(np.array([[[[5.0]]]])).ravel(), \"(expect [0 0 0 5])\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ SUBMIT — Run this cell to check your solution\n",
+    "from torch_judge import check\n",
+    "check(\"numpy_maxpool2d\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/torch_judge/tasks/_registry.py
+++ b/torch_judge/tasks/_registry.py
@@ -19,6 +19,7 @@ CATEGORY_ORDER = [
     "LLM 推理组件",
     "扩散模型训练",
     "ML 基础与解码策略",
+    "NumPy 手写神经网络",
     "RLHF",
 ]
 _CATEGORY_INDEX = {c: i for i, c in enumerate(CATEGORY_ORDER)}

--- a/torch_judge/tasks/cfg.py
+++ b/torch_judge/tasks/cfg.py
@@ -1,0 +1,130 @@
+"""Classifier-Free Guidance (CFG) with the optional std-rescale trick."""
+
+TASK = {
+    "category": "扩散模型训练",
+    "title": "Classifier-Free Guidance",
+    "difficulty": "Medium",
+    "function_name": "classifier_free_guidance",
+    "hint": (
+        "eps = eps_uncond + w * (eps_cond - eps_uncond). With this convention w=1 means 'no guidance' "
+        "(pure conditional) and w=0 means unconditional. For rescale: compute per-sample std over all "
+        "non-batch dims, scale the guided prediction by std_cond / std_cfg, then blend: "
+        "phi * rescaled + (1 - phi) * eps_cfg."
+    ),
+    "tests": [
+        {
+            "name": "Basic combination formula",
+            "code": """
+import torch
+torch.manual_seed(0)
+eps_u = torch.randn(4, 3, 8, 8)
+eps_c = torch.randn(4, 3, 8, 8)
+out = {fn}(eps_u, eps_c, 7.5)
+assert out.shape == eps_u.shape, f'Shape mismatch: {out.shape}'
+expected = eps_u + 7.5 * (eps_c - eps_u)
+assert torch.allclose(out, expected, atol=1e-6), 'Guided prediction does not match eps_u + w*(eps_c - eps_u)'
+""",
+        },
+        {
+            "name": "w=1 is pure conditional, w=0 is unconditional",
+            "code": """
+import torch
+torch.manual_seed(1)
+eps_u = torch.randn(2, 4)
+eps_c = torch.randn(2, 4)
+out1 = {fn}(eps_u, eps_c, 1.0)
+assert torch.allclose(out1, eps_c, atol=1e-6), 'guidance_scale=1.0 must return the conditional prediction'
+out0 = {fn}(eps_u, eps_c, 0.0)
+assert torch.allclose(out0, eps_u, atol=1e-6), 'guidance_scale=0.0 must return the unconditional prediction'
+""",
+        },
+        {
+            "name": "Extrapolation direction is amplified",
+            "code": """
+import torch
+torch.manual_seed(2)
+eps_u = torch.randn(3, 5)
+eps_c = torch.randn(3, 5)
+w = 5.0
+out = {fn}(eps_u, eps_c, w)
+delta = out - eps_u
+assert torch.allclose(delta, w * (eps_c - eps_u), atol=1e-6), \\
+    'CFG extrapolates along (cond - uncond); the step must be exactly w times that direction'
+""",
+        },
+        {
+            "name": "Negative / fractional guidance scales",
+            "code": """
+import torch
+torch.manual_seed(3)
+eps_u = torch.randn(2, 3, 4, 4)
+eps_c = torch.randn(2, 3, 4, 4)
+for w in [-2.0, 0.5, 3.0, 12.0]:
+    out = {fn}(eps_u, eps_c, w)
+    expected = eps_u + w * (eps_c - eps_u)
+    assert torch.allclose(out, expected, atol=1e-6), f'Wrong result for guidance_scale={w}'
+""",
+        },
+        {
+            "name": "rescale=1.0 restores the conditional std",
+            "code": """
+import torch
+torch.manual_seed(4)
+eps_u = torch.randn(4, 3, 8, 8)
+eps_c = torch.randn(4, 3, 8, 8)
+out = {fn}(eps_u, eps_c, 7.5, rescale=1.0)
+dims = (1, 2, 3)
+std_out = out.std(dim=dims)
+std_cond = eps_c.std(dim=dims)
+assert torch.allclose(std_out, std_cond, atol=1e-4), \\
+    f'With rescale=1.0 the per-sample std must match the conditional std: {std_out} vs {std_cond}'
+""",
+        },
+        {
+            "name": "rescale blends between guided and rescaled",
+            "code": """
+import torch
+torch.manual_seed(5)
+eps_u = torch.randn(3, 2, 6, 6)
+eps_c = torch.randn(3, 2, 6, 6)
+w, phi = 6.0, 0.7
+out = {fn}(eps_u, eps_c, w, rescale=phi)
+dims = (1, 2, 3)
+cfg = eps_u + w * (eps_c - eps_u)
+ratio = eps_c.std(dim=dims, keepdim=True) / cfg.std(dim=dims, keepdim=True)
+expected = phi * (cfg * ratio) + (1 - phi) * cfg
+assert torch.allclose(out, expected, atol=1e-5), 'rescale must linearly blend the rescaled and raw guided predictions'
+""",
+        },
+        {
+            "name": "rescale is per-sample, not global",
+            "code": """
+import torch
+torch.manual_seed(6)
+eps_u = torch.randn(2, 3, 8, 8)
+eps_c = torch.randn(2, 3, 8, 8)
+out = {fn}(eps_u, eps_c, 7.5, rescale=1.0)
+# Scale only sample 0 — sample 1 must be untouched
+eps_u2, eps_c2 = eps_u.clone(), eps_c.clone()
+eps_u2[0] *= 10
+eps_c2[0] *= 10
+out2 = {fn}(eps_u2, eps_c2, 7.5, rescale=1.0)
+assert torch.allclose(out[1], out2[1], atol=1e-5), \\
+    'Statistics must be computed per sample — changing sample 0 changed sample 1'
+assert torch.allclose(out2[0], out[0] * 10, atol=1e-4), 'Sample 0 should scale linearly with its inputs'
+""",
+        },
+        {
+            "name": "rescale=0.0 is a no-op",
+            "code": """
+import torch
+torch.manual_seed(7)
+eps_u = torch.randn(2, 3, 4, 4)
+eps_c = torch.randn(2, 3, 4, 4)
+a = {fn}(eps_u, eps_c, 7.5)
+b = {fn}(eps_u, eps_c, 7.5, rescale=0.0)
+assert torch.allclose(a, b, atol=1e-6), 'rescale=0.0 must equal the plain guided prediction'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/dmd2.py
+++ b/torch_judge/tasks/dmd2.py
@@ -1,0 +1,124 @@
+"""DMD2 — the distribution matching (score-difference) loss used to distill a one-step generator."""
+
+TASK = {
+    "category": "扩散模型训练",
+    "title": "DMD2 Distribution Matching Loss",
+    "difficulty": "Hard",
+    "function_name": "dmd_loss",
+    "hint": (
+        "The reverse-KL gradient w.r.t. a generated sample is the score difference "
+        "(s_fake - s_real), which in x0-prediction space is proportional to (pred_fake - pred_real). "
+        "Normalize it per sample by |pred_real - x_gen|.mean() so the scale is dimension-free, then "
+        "turn the gradient into a differentiable surrogate: loss = 0.5 * mse(x_gen, stopgrad(x_gen - grad)). "
+        "Differentiating that gives exactly d(loss)/d(x_gen) = grad / numel."
+    ),
+    "tests": [
+        {
+            "name": "Scalar, non-negative loss",
+            "code": """
+import torch
+torch.manual_seed(0)
+x = torch.randn(4, 3, 8, 8, requires_grad=True)
+pred_real = torch.randn(4, 3, 8, 8)
+pred_fake = torch.randn(4, 3, 8, 8)
+loss = {fn}(x, pred_real, pred_fake)
+assert isinstance(loss, torch.Tensor), f'Loss must be a tensor, got {type(loss)}'
+assert loss.dim() == 0, f'Loss must be a scalar, got shape {loss.shape}'
+assert loss.item() >= 0, f'Loss must be non-negative, got {loss.item()}'
+""",
+        },
+        {
+            "name": "Zero loss when the two scores agree",
+            "code": """
+import torch
+torch.manual_seed(1)
+x = torch.randn(2, 3, 4, 4, requires_grad=True)
+pred = torch.randn(2, 3, 4, 4)
+loss = {fn}(x, pred, pred)
+assert loss.item() < 1e-12, f'If pred_fake == pred_real the distributions match, loss must be 0, got {loss.item()}'
+loss.backward()
+assert x.grad.abs().max() < 1e-10, 'Gradient must vanish when the two scores agree'
+""",
+        },
+        {
+            "name": "Gradient equals the normalized score difference",
+            "code": """
+import torch
+torch.manual_seed(2)
+x = torch.randn(4, 3, 8, 8, requires_grad=True)
+pred_real = torch.randn(4, 3, 8, 8)
+pred_fake = torch.randn(4, 3, 8, 8)
+loss = {fn}(x, pred_real, pred_fake)
+loss.backward()
+normalizer = (pred_real - x.detach()).abs().mean(dim=(1, 2, 3), keepdim=True)
+expected = (pred_fake - pred_real) / (normalizer + 1e-8) / x.numel()
+assert x.grad is not None, 'No gradient reached x_gen'
+assert torch.allclose(x.grad, expected, atol=1e-6), \\
+    'd(loss)/d(x_gen) must equal (pred_fake - pred_real) / normalizer / numel'
+""",
+        },
+        {
+            "name": "No gradient leaks into the score predictions",
+            "code": """
+import torch
+torch.manual_seed(3)
+x = torch.randn(2, 3, 4, 4, requires_grad=True)
+pred_real = torch.randn(2, 3, 4, 4, requires_grad=True)
+pred_fake = torch.randn(2, 3, 4, 4, requires_grad=True)
+loss = {fn}(x, pred_real, pred_fake)
+loss.backward()
+assert pred_real.grad is None or pred_real.grad.abs().max() < 1e-12, \\
+    'The regression target must be detached — the frozen teacher must not receive gradient'
+assert pred_fake.grad is None or pred_fake.grad.abs().max() < 1e-12, \\
+    'The fake score model is trained by its own diffusion loss, not by this one — detach the target'
+""",
+        },
+        {
+            "name": "Scale invariance from the normalizer",
+            "code": """
+import torch
+torch.manual_seed(4)
+x = torch.randn(3, 2, 4, 4)
+pred_real = torch.randn(3, 2, 4, 4)
+pred_fake = torch.randn(3, 2, 4, 4)
+c = 50.0
+loss_a = {fn}(x, pred_real, pred_fake)
+loss_b = {fn}(x * c, pred_real * c, pred_fake * c)
+assert torch.allclose(loss_a, loss_b, rtol=1e-3, atol=1e-6), \\
+    f'Dividing by |pred_real - x_gen|.mean() makes the loss scale-invariant: {loss_a.item()} vs {loss_b.item()}'
+""",
+        },
+        {
+            "name": "Normalizer is per-sample",
+            "code": """
+import torch
+torch.manual_seed(5)
+x = torch.randn(2, 6)
+pred_real = torch.randn(2, 6)
+pred_fake = torch.randn(2, 6)
+base = {fn}(x, pred_real, pred_fake)
+x2, pr2, pf2 = x.clone(), pred_real.clone(), pred_fake.clone()
+x2[0] *= 20
+pr2[0] *= 20
+pf2[0] *= 20
+scaled = {fn}(x2, pr2, pf2)
+assert torch.allclose(base, scaled, rtol=1e-3, atol=1e-6), \\
+    'Rescaling one sample changed the loss — the normalizer must be computed per sample, not over the whole batch'
+""",
+        },
+        {
+            "name": "Finite when the normalizer degenerates",
+            "code": """
+import torch
+torch.manual_seed(6)
+x = torch.randn(2, 4, requires_grad=True)
+pred_real = x.detach().clone()   # normalizer becomes exactly 0
+pred_fake = torch.randn(2, 4)
+loss = {fn}(x, pred_real, pred_fake)
+assert not torch.isnan(loss).any(), 'Loss became NaN — guard the division with eps and/or torch.nan_to_num'
+loss.backward()
+assert not torch.isnan(x.grad).any(), 'Gradient became NaN on a degenerate normalizer'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/flow_matching.py
+++ b/torch_judge/tasks/flow_matching.py
@@ -1,0 +1,115 @@
+"""Flow Matching / Rectified Flow training objective."""
+
+TASK = {
+    "category": "扩散模型训练",
+    "title": "Flow Matching Loss (Rectified Flow)",
+    "difficulty": "Medium",
+    "function_name": "flow_matching_loss",
+    "hint": (
+        "Straight-line probability path: x_t = (1 - t) * x0 + t * x1, so the target velocity is "
+        "the constant u = x1 - x0 (independent of t!). Loss = mean((model(x_t, t) - u) ** 2). "
+        "t has shape (B,) but x has shape (B, ...) — reshape t to (B, 1, 1, ...) so it broadcasts "
+        "over every feature dimension, otherwise you silently mix samples."
+    ),
+    "tests": [
+        {
+            "name": "Scalar loss, zero-velocity model",
+            "code": """
+import torch
+torch.manual_seed(0)
+x0 = torch.randn(8, 4)
+x1 = torch.randn(8, 4)
+t = torch.rand(8)
+loss = {fn}(lambda x, tt: torch.zeros_like(x), x0, x1, t)
+assert isinstance(loss, torch.Tensor), f'Loss must be a tensor, got {type(loss)}'
+assert loss.dim() == 0, f'Loss must be a scalar, got shape {loss.shape}'
+expected = ((x1 - x0) ** 2).mean()
+assert torch.allclose(loss, expected, atol=1e-6), f'Expected {expected.item()}, got {loss.item()}'
+""",
+        },
+        {
+            "name": "Perfect velocity model gives zero loss",
+            "code": """
+import torch
+torch.manual_seed(1)
+x0 = torch.randn(6, 3, 8, 8)
+x1 = torch.randn(6, 3, 8, 8)
+t = torch.rand(6)
+loss = {fn}(lambda x, tt: x1 - x0, x0, x1, t)
+assert loss.item() < 1e-10, f'A model that outputs the exact velocity must give ~0 loss, got {loss.item()}'
+""",
+        },
+        {
+            "name": "Interpolation path x_t = (1-t)*x0 + t*x1",
+            "code": """
+import torch
+torch.manual_seed(2)
+seen = {}
+def model(x, tt):
+    seen['x_t'] = x
+    return torch.zeros_like(x)
+x0 = torch.randn(3, 2, 4, 4)
+x1 = torch.randn(3, 2, 4, 4)
+t = torch.tensor([0.0, 0.5, 1.0])
+{fn}(model, x0, x1, t)
+assert 'x_t' in seen, 'The model was never called — you must evaluate model(x_t, t)'
+x_t = seen['x_t']
+assert x_t.shape == x0.shape, f'x_t shape {x_t.shape} should match x0 shape {x0.shape}'
+assert torch.allclose(x_t[0], x0[0], atol=1e-6), 't=0 must give pure noise x0'
+assert torch.allclose(x_t[2], x1[2], atol=1e-6), 't=1 must give pure data x1'
+assert torch.allclose(x_t[1], 0.5 * (x0[1] + x1[1]), atol=1e-6), 't=0.5 must give the midpoint'
+""",
+        },
+        {
+            "name": "Per-sample t broadcasting",
+            "code": """
+import torch
+torch.manual_seed(3)
+seen = {}
+def model(x, tt):
+    seen['x_t'] = x
+    return torch.zeros_like(x)
+x0 = torch.zeros(4, 5)
+x1 = torch.ones(4, 5)
+t = torch.tensor([0.0, 0.25, 0.75, 1.0])
+{fn}(model, x0, x1, t)
+x_t = seen['x_t']
+for i, ti in enumerate([0.0, 0.25, 0.75, 1.0]):
+    assert torch.allclose(x_t[i], torch.full((5,), ti), atol=1e-6), \\
+        f'Sample {i} should be all {ti}, got {x_t[i]} — did you broadcast t per-sample?'
+""",
+        },
+        {
+            "name": "Velocity target is constant in t",
+            "code": """
+import torch
+torch.manual_seed(4)
+x0 = torch.randn(5, 7)
+x1 = torch.randn(5, 7)
+const = lambda x, tt: torch.full_like(x, 0.3)
+loss_a = {fn}(const, x0, x1, torch.zeros(5))
+loss_b = {fn}(const, x0, x1, torch.ones(5))
+assert torch.allclose(loss_a, loss_b, atol=1e-6), \\
+    'The regression target x1 - x0 does not depend on t, so a t-independent model must give the same loss'
+expected = ((0.3 - (x1 - x0)) ** 2).mean()
+assert torch.allclose(loss_a, expected, atol=1e-6), f'Expected {expected.item()}, got {loss_a.item()}'
+""",
+        },
+        {
+            "name": "Gradient flows into the model",
+            "code": """
+import torch
+import torch.nn as nn
+torch.manual_seed(5)
+net = nn.Linear(4, 4)
+x0 = torch.randn(8, 4)
+x1 = torch.randn(8, 4)
+t = torch.rand(8)
+loss = {fn}(lambda x, tt: net(x), x0, x1, t)
+loss.backward()
+assert net.weight.grad is not None, 'No gradient reached the model parameters'
+assert net.weight.grad.abs().sum() > 0, 'Model gradient is all zeros — did you detach something?'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_conv2d.py
+++ b/torch_judge/tasks/numpy_conv2d.py
@@ -1,0 +1,118 @@
+"""2-D convolution forward pass — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "Conv2D Forward (NumPy)",
+    "difficulty": "Hard",
+    "function_name": "conv2d_forward",
+    "hint": (
+        "H_out = (H + 2*padding - KH) // stride + 1 (same for W). Pad only the spatial dims with "
+        "np.pad(x, ((0,0),(0,0),(p,p),(p,p))). Then for each output position (i, j) slice the patch "
+        "x[:, :, i*s:i*s+KH, j*s:j*s+KW] of shape (N, C, KH, KW) and contract it with w (F, C, KH, KW) "
+        "over the last three axes — np.tensordot(patch, w, axes=([1,2,3],[1,2,3])) gives (N, F). "
+        "Deep learning 'convolution' is really cross-correlation: no kernel flipping."
+    ),
+    "tests": [
+        {
+            "name": "Output shape with stride and padding",
+            "code": """
+import numpy as np
+np.random.seed(0)
+x = np.random.randn(2, 3, 8, 8)
+w = np.random.randn(4, 3, 3, 3)
+b = np.random.randn(4)
+out = {fn}(x, w, b, stride=1, padding=0)
+assert isinstance(out, np.ndarray), f'Must return np.ndarray, got {type(out)}'
+assert out.shape == (2, 4, 6, 6), f'Expected (2, 4, 6, 6), got {out.shape}'
+out = {fn}(x, w, b, stride=2, padding=1)
+assert out.shape == (2, 4, 4, 4), f'Expected (2, 4, 4, 4) for stride=2 padding=1, got {out.shape}'
+""",
+        },
+        {
+            "name": "Matches F.conv2d",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(1)
+x = np.random.randn(3, 2, 7, 9)
+w = np.random.randn(5, 2, 3, 3)
+b = np.random.randn(5)
+out = {fn}(x, w, b, stride=1, padding=1)
+ref = torch.nn.functional.conv2d(torch.tensor(x), torch.tensor(w), torch.tensor(b), stride=1, padding=1)
+assert np.allclose(out, ref.numpy(), atol=1e-8), 'Output does not match torch.nn.functional.conv2d'
+""",
+        },
+        {
+            "name": "Matches F.conv2d with stride 2",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(2)
+x = np.random.randn(2, 4, 10, 10)
+w = np.random.randn(3, 4, 5, 5)
+b = np.random.randn(3)
+out = {fn}(x, w, b, stride=2, padding=2)
+ref = torch.nn.functional.conv2d(torch.tensor(x), torch.tensor(w), torch.tensor(b), stride=2, padding=2)
+assert out.shape == tuple(ref.shape), f'Shape {out.shape} != {tuple(ref.shape)}'
+assert np.allclose(out, ref.numpy(), atol=1e-8), 'Mismatch with stride=2, padding=2'
+""",
+        },
+        {
+            "name": "Identity kernel copies the input",
+            "code": """
+import numpy as np
+np.random.seed(3)
+x = np.random.randn(1, 1, 5, 5)
+w = np.zeros((1, 1, 3, 3))
+w[0, 0, 1, 1] = 1.0          # center tap only
+b = np.zeros(1)
+out = {fn}(x, w, b, stride=1, padding=1)
+assert np.allclose(out, x, atol=1e-10), 'A center-tap kernel with padding=1 must reproduce the input'
+""",
+        },
+        {
+            "name": "No kernel flipping (cross-correlation)",
+            "code": """
+import numpy as np
+x = np.zeros((1, 1, 3, 3))
+x[0, 0, 0, 0] = 1.0
+w = np.arange(9, dtype=np.float64).reshape(1, 1, 3, 3)
+b = np.zeros(1)
+out = {fn}(x, w, b, stride=1, padding=0)
+assert out.shape == (1, 1, 1, 1)
+assert np.allclose(out[0, 0, 0, 0], 0.0), \\
+    f'Expected w[0,0] * x[0,0] = 0 (cross-correlation). Got {out[0, 0, 0, 0]} — you flipped the kernel'
+""",
+        },
+        {
+            "name": "Bias is added per output channel",
+            "code": """
+import numpy as np
+np.random.seed(4)
+x = np.random.randn(2, 3, 6, 6)
+w = np.random.randn(4, 3, 3, 3)
+zero_b = np.zeros(4)
+b = np.array([1.0, -2.0, 0.5, 10.0])
+out0 = {fn}(x, w, zero_b, stride=1, padding=0)
+out1 = {fn}(x, w, b, stride=1, padding=0)
+diff = out1 - out0
+for f in range(4):
+    assert np.allclose(diff[:, f], b[f], atol=1e-9), f'Bias for channel {f} not added correctly'
+""",
+        },
+        {
+            "name": "Pure NumPy — no torch",
+            "code": """
+import numpy as np
+np.random.seed(5)
+x = np.random.randn(1, 1, 4, 4)
+w = np.random.randn(1, 1, 2, 2)
+b = np.zeros(1)
+out = {fn}(x, w, b)
+assert isinstance(out, np.ndarray), f'Must return np.ndarray, got {type(out)}'
+assert out.shape == (1, 1, 3, 3), f'Expected (1, 1, 3, 3) with the default stride=1, padding=0, got {out.shape}'
+assert not type(out).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_conv2d_backward.py
+++ b/torch_judge/tasks/numpy_conv2d_backward.py
@@ -1,0 +1,128 @@
+"""2-D convolution backward pass — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "Conv2D Backward (NumPy)",
+    "difficulty": "Hard",
+    "function_name": "conv2d_backward",
+    "hint": (
+        "db = dout.sum(axis=(0, 2, 3)) — every spatial position shares the same bias. "
+        "Loop over output positions again; let d = dout[:, :, i, j] of shape (N, F) and "
+        "patch = x_pad[:, :, i*s:i*s+KH, j*s:j*s+KW] of shape (N, C, KH, KW). Then "
+        "dw += tensordot(d, patch, axes=([0],[0])) and the same window of dx_pad gets "
+        "+= tensordot(d, w, axes=([1],[0])). Windows overlap when stride < kernel, so ACCUMULATE (+=) "
+        "instead of assigning. Finally crop the padding off dx_pad."
+    ),
+    "tests": [
+        {
+            "name": "Gradient shapes",
+            "code": """
+import numpy as np
+np.random.seed(0)
+x = np.random.randn(2, 3, 8, 8)
+w = np.random.randn(4, 3, 3, 3)
+dout = np.random.randn(2, 4, 6, 6)
+dx, dw, db = {fn}(dout, x, w, stride=1, padding=0)
+assert dx.shape == x.shape, f'dx shape {dx.shape} != x shape {x.shape}'
+assert dw.shape == w.shape, f'dw shape {dw.shape} != w shape {w.shape}'
+assert db.shape == (4,), f'db shape {db.shape} != (4,)'
+""",
+        },
+        {
+            "name": "Bias gradient sums over batch and space",
+            "code": """
+import numpy as np
+np.random.seed(1)
+x = np.random.randn(2, 2, 6, 6)
+w = np.random.randn(3, 2, 3, 3)
+dout = np.random.randn(2, 3, 4, 4)
+_, _, db = {fn}(dout, x, w, stride=1, padding=0)
+assert np.allclose(db, dout.sum(axis=(0, 2, 3)), atol=1e-10), 'db must be dout summed over N, H_out, W_out'
+""",
+        },
+        {
+            "name": "Matches autograd (stride 1, padding 1)",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(2)
+x = np.random.randn(3, 2, 7, 7)
+w = np.random.randn(4, 2, 3, 3)
+dout = np.random.randn(3, 4, 7, 7)
+dx, dw, db = {fn}(dout, x, w, stride=1, padding=1)
+
+tx = torch.tensor(x, requires_grad=True)
+tw = torch.tensor(w, requires_grad=True)
+tb = torch.zeros(4, dtype=torch.float64, requires_grad=True)
+out = torch.nn.functional.conv2d(tx, tw, tb, stride=1, padding=1)
+out.backward(torch.tensor(dout))
+assert np.allclose(dx, tx.grad.numpy(), atol=1e-8), 'dx mismatch'
+assert np.allclose(dw, tw.grad.numpy(), atol=1e-8), 'dw mismatch'
+assert np.allclose(db, tb.grad.numpy(), atol=1e-8), 'db mismatch'
+""",
+        },
+        {
+            "name": "Matches autograd (stride 2, padding 2)",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(3)
+x = np.random.randn(2, 3, 9, 11)
+w = np.random.randn(5, 3, 5, 5)
+tx = torch.tensor(x, requires_grad=True)
+tw = torch.tensor(w, requires_grad=True)
+tb = torch.zeros(5, dtype=torch.float64, requires_grad=True)
+out = torch.nn.functional.conv2d(tx, tw, tb, stride=2, padding=2)
+dout = np.random.randn(*out.shape)
+dx, dw, db = {fn}(dout, x, w, stride=2, padding=2)
+out.backward(torch.tensor(dout))
+assert np.allclose(dx, tx.grad.numpy(), atol=1e-8), 'dx mismatch with stride=2'
+assert np.allclose(dw, tw.grad.numpy(), atol=1e-8), 'dw mismatch with stride=2'
+assert np.allclose(db, tb.grad.numpy(), atol=1e-8), 'db mismatch with stride=2'
+""",
+        },
+        {
+            "name": "Overlapping windows accumulate",
+            "code": """
+import numpy as np
+x = np.zeros((1, 1, 4, 4))
+w = np.ones((1, 1, 2, 2))
+dout = np.ones((1, 1, 3, 3))          # stride 1 -> interior pixels are covered 4 times
+dx, _, _ = {fn}(dout, x, w, stride=1, padding=0)
+assert np.allclose(dx[0, 0, 0, 0], 1.0), f'Corner pixel is used once, expected 1.0, got {dx[0, 0, 0, 0]}'
+assert np.allclose(dx[0, 0, 1, 1], 4.0), \\
+    f'Interior pixel is used by 4 windows, expected 4.0, got {dx[0, 0, 1, 1]} — accumulate with += instead of ='
+""",
+        },
+        {
+            "name": "Padding is cropped off dx",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(4)
+x = np.random.randn(1, 2, 5, 5)
+w = np.random.randn(3, 2, 3, 3)
+dout = np.random.randn(1, 3, 5, 5)
+dx, _, _ = {fn}(dout, x, w, stride=1, padding=1)
+assert dx.shape == x.shape, f'dx must have the shape of x, not of the padded input: {dx.shape}'
+tx = torch.tensor(x, requires_grad=True)
+out = torch.nn.functional.conv2d(tx, torch.tensor(w), None, stride=1, padding=1)
+out.backward(torch.tensor(dout))
+assert np.allclose(dx, tx.grad.numpy(), atol=1e-8), 'dx mismatch — did you crop the padded border correctly?'
+""",
+        },
+        {
+            "name": "Pure NumPy — no torch",
+            "code": """
+import numpy as np
+np.random.seed(5)
+x = np.random.randn(1, 1, 4, 4)
+w = np.random.randn(1, 1, 2, 2)
+dout = np.random.randn(1, 1, 3, 3)
+dx, dw, db = {fn}(dout, x, w)
+assert isinstance(dx, np.ndarray) and isinstance(dw, np.ndarray), 'Must return NumPy arrays'
+assert not type(dx).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_maxpool2d.py
+++ b/torch_judge/tasks/numpy_maxpool2d.py
@@ -1,0 +1,115 @@
+"""Max pooling forward + backward closure — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "MaxPool2D Forward & Backward (NumPy)",
+    "difficulty": "Medium",
+    "function_name": "maxpool2d",
+    "hint": (
+        "Return (out, backward) where backward(dout) -> dx. Pooling has no parameters, so all the "
+        "backward pass needs is WHERE each maximum came from: record the argmax inside every window "
+        "during the forward pass (flatten the window and use argmax, then unflatten with divmod). "
+        "Backward is pure routing — each dout value is added to its winner position, everything else "
+        "gets 0. Use += so overlapping windows (stride < kernel_size) accumulate."
+    ),
+    "tests": [
+        {
+            "name": "Forward shape and returned closure",
+            "code": """
+import numpy as np
+np.random.seed(0)
+x = np.random.randn(2, 3, 8, 8)
+out, backward = {fn}(x, kernel_size=2, stride=2)
+assert isinstance(out, np.ndarray), f'First return must be np.ndarray, got {type(out)}'
+assert out.shape == (2, 3, 4, 4), f'Expected (2, 3, 4, 4), got {out.shape}'
+assert callable(backward), 'Second return value must be a callable backward(dout) -> dx'
+dx = backward(np.ones_like(out))
+assert dx.shape == x.shape, f'dx shape {dx.shape} != x shape {x.shape}'
+""",
+        },
+        {
+            "name": "Forward matches F.max_pool2d",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(1)
+x = np.random.randn(3, 4, 10, 10)
+out, _ = {fn}(x, kernel_size=2, stride=2)
+ref = torch.nn.functional.max_pool2d(torch.tensor(x), kernel_size=2, stride=2)
+assert np.allclose(out, ref.numpy(), atol=1e-10), 'Forward output does not match torch max_pool2d'
+""",
+        },
+        {
+            "name": "Non-square windows / stride 3",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(2)
+x = np.random.randn(2, 2, 9, 9)
+out, _ = {fn}(x, kernel_size=3, stride=3)
+ref = torch.nn.functional.max_pool2d(torch.tensor(x), kernel_size=3, stride=3)
+assert out.shape == tuple(ref.shape), f'Shape {out.shape} != {tuple(ref.shape)}'
+assert np.allclose(out, ref.numpy(), atol=1e-10), 'Mismatch with kernel_size=3, stride=3'
+""",
+        },
+        {
+            "name": "Backward routes gradient to the argmax only",
+            "code": """
+import numpy as np
+x = np.array([[[[1.0, 2.0], [3.0, 9.0]]]])     # (1, 1, 2, 2), max at (1, 1)
+out, backward = {fn}(x, kernel_size=2, stride=2)
+assert np.allclose(out, 9.0), f'Max should be 9.0, got {out}'
+dx = backward(np.array([[[[5.0]]]]))
+expected = np.array([[[[0.0, 0.0], [0.0, 5.0]]]])
+assert np.allclose(dx, expected), f'Gradient must go only to the max position, got {dx}'
+assert np.count_nonzero(dx) == 1, 'Exactly one element per window may receive gradient'
+""",
+        },
+        {
+            "name": "Backward matches autograd",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(3)
+x = np.random.randn(2, 3, 8, 8)
+out, backward = {fn}(x, kernel_size=2, stride=2)
+dout = np.random.randn(*out.shape)
+dx = backward(dout)
+tx = torch.tensor(x, requires_grad=True)
+ref = torch.nn.functional.max_pool2d(tx, kernel_size=2, stride=2)
+ref.backward(torch.tensor(dout))
+assert np.allclose(dx, tx.grad.numpy(), atol=1e-10), 'Backward does not match autograd'
+""",
+        },
+        {
+            "name": "Overlapping windows accumulate",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(4)
+x = np.random.randn(1, 1, 5, 5)
+out, backward = {fn}(x, kernel_size=3, stride=1)
+dout = np.ones_like(out)
+dx = backward(dout)
+tx = torch.tensor(x, requires_grad=True)
+ref = torch.nn.functional.max_pool2d(tx, kernel_size=3, stride=1)
+ref.backward(torch.tensor(dout))
+assert np.allclose(dx, tx.grad.numpy(), atol=1e-10), \\
+    'With stride < kernel_size a pixel can win several windows — accumulate with += instead of ='
+assert dx.sum() > 0, 'Gradient vanished entirely'
+""",
+        },
+        {
+            "name": "Pure NumPy — no torch",
+            "code": """
+import numpy as np
+np.random.seed(5)
+x = np.random.randn(1, 1, 4, 4)
+out, backward = {fn}(x, kernel_size=2, stride=2)
+dx = backward(np.ones_like(out))
+assert not type(out).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+assert not type(dx).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_mlp_backward.py
+++ b/torch_judge/tasks/numpy_mlp_backward.py
@@ -1,0 +1,149 @@
+"""Full backpropagation through an L-layer ReLU MLP with softmax cross-entropy — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "MLP Backpropagation (NumPy)",
+    "difficulty": "Hard",
+    "function_name": "mlp_loss_and_grads",
+    "hint": (
+        "Forward once and CACHE (A_prev, Z) for every layer. Start the backward pass from the fused "
+        "softmax-CE gradient dZ_last = (p - onehot(y)) / N. Then for each layer, walking backwards: "
+        "dW = A_prev.T @ dZ, db = dZ.sum(axis=0), dA_prev = dZ @ W.T, and dZ_prev = dA_prev * (Z_prev > 0). "
+        "Every gradient has exactly the shape of the thing it differentiates."
+    ),
+    "tests": [
+        {
+            "name": "Return structure and shapes",
+            "code": """
+import numpy as np
+np.random.seed(0)
+X = np.random.randn(6, 4)
+labels = np.random.randint(0, 3, size=6)
+params = [(np.random.randn(4, 5), np.random.randn(5)),
+          (np.random.randn(5, 3), np.random.randn(3))]
+loss, grads = {fn}(X, labels, params)
+assert np.ndim(loss) == 0, f'loss must be a scalar, got shape {np.shape(loss)}'
+assert len(grads) == len(params), f'Need one (dW, db) pair per layer, got {len(grads)}'
+for (dW, db), (W, b) in zip(grads, params):
+    assert dW.shape == W.shape, f'dW shape {dW.shape} != W shape {W.shape}'
+    assert db.shape == b.shape, f'db shape {db.shape} != b shape {b.shape}'
+""",
+        },
+        {
+            "name": "Loss matches cross-entropy",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(1)
+X = np.random.randn(8, 5)
+labels = np.random.randint(0, 4, size=8)
+params = [(np.random.randn(5, 7), np.random.randn(7)), (np.random.randn(7, 4), np.random.randn(4))]
+loss, _ = {fn}(X, labels, params)
+t = torch.tensor(X)
+for i, (W, b) in enumerate(params):
+    t = t @ torch.tensor(W) + torch.tensor(b)
+    if i < len(params) - 1:
+        t = torch.relu(t)
+ref = torch.nn.functional.cross_entropy(t, torch.tensor(labels)).item()
+assert abs(float(loss) - ref) < 1e-9, f'Loss {float(loss)} != reference {ref}'
+""",
+        },
+        {
+            "name": "Gradients match autograd (3 layers)",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(2)
+X = np.random.randn(9, 6)
+labels = np.random.randint(0, 4, size=9)
+shapes = [(6, 8), (8, 5), (5, 4)]
+params = [(np.random.randn(*s), np.random.randn(s[1])) for s in shapes]
+loss, grads = {fn}(X, labels, params)
+
+ts = [(torch.tensor(W, requires_grad=True), torch.tensor(b, requires_grad=True)) for W, b in params]
+t = torch.tensor(X)
+for i, (W, b) in enumerate(ts):
+    t = t @ W + b
+    if i < len(ts) - 1:
+        t = torch.relu(t)
+torch.nn.functional.cross_entropy(t, torch.tensor(labels)).backward()
+
+for i, ((dW, db), (W, b)) in enumerate(zip(grads, ts)):
+    assert np.allclose(dW, W.grad.numpy(), atol=1e-8), f'dW mismatch at layer {i}'
+    assert np.allclose(db, b.grad.numpy(), atol=1e-8), f'db mismatch at layer {i}'
+""",
+        },
+        {
+            "name": "Matches numerical gradient",
+            "code": """
+import numpy as np
+np.random.seed(3)
+X = np.random.randn(5, 3)
+labels = np.array([0, 1, 2, 1, 0])
+params = [(np.random.randn(3, 4), np.random.randn(4)), (np.random.randn(4, 3), np.random.randn(3))]
+loss, grads = {fn}(X, labels, params)
+eps = 1e-6
+W = params[0][0]
+num = np.zeros_like(W)
+for i in range(W.shape[0]):
+    for j in range(W.shape[1]):
+        orig = W[i, j]
+        W[i, j] = orig + eps
+        lp, _ = {fn}(X, labels, params)
+        W[i, j] = orig - eps
+        lm, _ = {fn}(X, labels, params)
+        W[i, j] = orig
+        num[i, j] = (float(lp) - float(lm)) / (2 * eps)
+assert np.allclose(grads[0][0], num, atol=1e-5), 'Analytic dW1 disagrees with the finite-difference gradient'
+""",
+        },
+        {
+            "name": "Dead ReLU units receive no gradient",
+            "code": """
+import numpy as np
+X = np.ones((3, 2))
+W1 = np.array([[-5.0, 1.0], [-5.0, 1.0]])
+b1 = np.array([-5.0, 0.0])          # unit 0 is always negative -> dead
+W2 = np.array([[1.0, -1.0], [2.0, 0.5]])
+b2 = np.zeros(2)
+labels = np.array([0, 1, 0])
+loss, grads = {fn}(X, labels, [(W1, b1), (W2, b2)])
+dW1, db1 = grads[0]
+assert np.allclose(dW1[:, 0], 0), f'Dead hidden unit must get zero weight gradient, got {dW1[:, 0]}'
+assert np.allclose(db1[0], 0), f'Dead hidden unit must get zero bias gradient, got {db1[0]}'
+assert np.abs(dW1[:, 1]).sum() > 0, 'The active hidden unit must receive gradient'
+""",
+        },
+        {
+            "name": "Gradient descent actually reduces the loss",
+            "code": """
+import numpy as np
+np.random.seed(4)
+X = np.random.randn(40, 4)
+labels = (X[:, 0] + X[:, 1] > 0).astype(np.int64)
+params = [(np.random.randn(4, 16) * 0.5, np.zeros(16)), (np.random.randn(16, 2) * 0.5, np.zeros(2))]
+first = None
+for step in range(300):
+    loss, grads = {fn}(X, labels, params)
+    if first is None:
+        first = float(loss)
+    for (W, b), (dW, db) in zip(params, grads):
+        W -= 0.1 * dW
+        b -= 0.1 * db
+assert float(loss) < first * 0.3, f'Loss barely moved: {first:.4f} -> {float(loss):.4f}; check the gradient signs'
+""",
+        },
+        {
+            "name": "Pure NumPy — no torch",
+            "code": """
+import numpy as np
+np.random.seed(5)
+X = np.random.randn(4, 3)
+labels = np.array([0, 1, 0, 1])
+params = [(np.random.randn(3, 2), np.random.randn(2))]
+loss, grads = {fn}(X, labels, params)
+assert not type(grads[0][0]).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_mlp_forward.py
+++ b/torch_judge/tasks/numpy_mlp_forward.py
@@ -1,0 +1,101 @@
+"""Forward pass of an L-layer ReLU MLP — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "MLP Forward Pass (NumPy)",
+    "difficulty": "Medium",
+    "function_name": "mlp_forward",
+    "hint": (
+        "A = X; for every (W, b): Z = A @ W + b, then A = relu(Z) — except after the LAST layer, "
+        "which stays linear (logits). relu is np.maximum(Z, 0). Note W has shape (in, out) here, "
+        "so it is A @ W, not A @ W.T. Broadcasting adds b of shape (out,) to every row."
+    ),
+    "tests": [
+        {
+            "name": "Output shape",
+            "code": """
+import numpy as np
+np.random.seed(0)
+X = np.random.randn(5, 4)
+params = [(np.random.randn(4, 6), np.random.randn(6)),
+          (np.random.randn(6, 3), np.random.randn(3))]
+out = {fn}(X, params)
+assert isinstance(out, np.ndarray), f'Must return np.ndarray, got {type(out)}'
+assert out.shape == (5, 3), f'Expected shape (5, 3), got {out.shape}'
+""",
+        },
+        {
+            "name": "Single layer is a plain affine map",
+            "code": """
+import numpy as np
+np.random.seed(1)
+X = np.random.randn(3, 4)
+W = np.random.randn(4, 2)
+b = np.random.randn(2)
+out = {fn}(X, [(W, b)])
+assert np.allclose(out, X @ W + b), 'With one layer there is no hidden activation — output must be X @ W + b'
+""",
+        },
+        {
+            "name": "Matches a reference 3-layer network",
+            "code": """
+import numpy as np
+np.random.seed(2)
+X = np.random.randn(7, 5)
+params = [(np.random.randn(5, 8), np.random.randn(8)),
+          (np.random.randn(8, 6), np.random.randn(6)),
+          (np.random.randn(6, 3), np.random.randn(3))]
+out = {fn}(X, params)
+a = X
+for i, (W, b) in enumerate(params):
+    z = a @ W + b
+    a = np.maximum(z, 0) if i < len(params) - 1 else z
+assert np.allclose(out, a, atol=1e-10), 'Output does not match the reference forward pass'
+""",
+        },
+        {
+            "name": "ReLU is applied to hidden layers only",
+            "code": """
+import numpy as np
+# Layer 1 always produces negative pre-activations -> ReLU kills them -> output is exactly b2
+X = np.ones((2, 3))
+W1 = -np.ones((3, 4))
+b1 = -np.ones(4)
+W2 = np.ones((4, 2))
+b2 = np.array([0.5, -1.5])
+out = {fn}(X, [(W1, b1), (W2, b2)])
+assert np.allclose(out, np.tile(b2, (2, 1))), \\
+    f'Dead hidden layer should leave only the output bias, got {out} — is ReLU applied to the hidden layer?'
+assert (out < 0).any(), 'The final layer must stay linear — do not apply ReLU to the logits'
+""",
+        },
+        {
+            "name": "Does not mutate its inputs",
+            "code": """
+import numpy as np
+np.random.seed(3)
+X = np.random.randn(4, 3)
+params = [(np.random.randn(3, 5), np.random.randn(5)), (np.random.randn(5, 2), np.random.randn(2))]
+X_copy = X.copy()
+saved = [(W.copy(), b.copy()) for W, b in params]
+out = {fn}(X, params)
+assert isinstance(out, np.ndarray) and out.shape == (4, 2), f'Expected an (4, 2) ndarray, got {out}'
+assert np.allclose(X, X_copy), 'X was modified in place'
+for (W, b), (W0, b0) in zip(params, saved):
+    assert np.allclose(W, W0) and np.allclose(b, b0), 'Parameters were modified in place'
+""",
+        },
+        {
+            "name": "Pure NumPy — no torch",
+            "code": """
+import numpy as np
+np.random.seed(4)
+X = np.random.randn(3, 3)
+params = [(np.random.randn(3, 3), np.random.randn(3))]
+out = {fn}(X, params)
+assert isinstance(out, np.ndarray), f'Must return np.ndarray, got {type(out)}'
+assert not type(out).__module__.startswith('torch'), 'Must use only NumPy, no PyTorch'
+""",
+        },
+    ],
+}

--- a/torch_judge/tasks/numpy_softmax_ce.py
+++ b/torch_judge/tasks/numpy_softmax_ce.py
@@ -1,0 +1,105 @@
+"""Softmax + cross-entropy loss and its gradient — pure NumPy."""
+
+TASK = {
+    "category": "NumPy 手写神经网络",
+    "title": "Softmax Cross-Entropy + Gradient (NumPy)",
+    "difficulty": "Medium",
+    "function_name": "softmax_cross_entropy",
+    "hint": (
+        "Stable softmax: subtract the row max before exp. loss = -mean(log p[i, y_i]). "
+        "The famous shortcut: fusing softmax with cross-entropy collapses the whole Jacobian into "
+        "dlogits = (p - onehot(y)) / N. Build it by copying p and subtracting 1 at the label positions."
+    ),
+    "tests": [
+        {
+            "name": "Return types and shapes",
+            "code": """
+import numpy as np
+np.random.seed(0)
+logits = np.random.randn(6, 4)
+labels = np.array([0, 1, 2, 3, 0, 1])
+loss, dlogits = {fn}(logits, labels)
+assert np.isscalar(loss) or np.ndim(loss) == 0, f'loss must be a scalar, got {np.shape(loss)}'
+assert isinstance(dlogits, np.ndarray), f'dlogits must be np.ndarray, got {type(dlogits)}'
+assert dlogits.shape == logits.shape, f'dlogits shape {dlogits.shape} != logits shape {logits.shape}'
+""",
+        },
+        {
+            "name": "Loss matches the reference",
+            "code": """
+import numpy as np
+np.random.seed(1)
+logits = np.random.randn(8, 5)
+labels = np.random.randint(0, 5, size=8)
+loss, _ = {fn}(logits, labels)
+z = logits - logits.max(axis=1, keepdims=True)
+logZ = np.log(np.exp(z).sum(axis=1))
+ref = float(np.mean(logZ - z[np.arange(8), labels]))
+assert abs(float(loss) - ref) < 1e-9, f'Loss {float(loss)} != reference {ref} (did you average over the batch?)'
+""",
+        },
+        {
+            "name": "Uniform logits give log(C)",
+            "code": """
+import numpy as np
+logits = np.zeros((4, 10))
+labels = np.array([0, 3, 7, 9])
+loss, dlogits = {fn}(logits, labels)
+assert abs(float(loss) - np.log(10)) < 1e-9, f'Uniform logits over 10 classes must give log(10)={np.log(10):.4f}, got {float(loss)}'
+""",
+        },
+        {
+            "name": "Gradient matches autograd",
+            "code": """
+import numpy as np
+import torch
+np.random.seed(2)
+logits = np.random.randn(7, 6)
+labels = np.random.randint(0, 6, size=7)
+_, dlogits = {fn}(logits, labels)
+t = torch.tensor(logits, requires_grad=True)
+ref_loss = torch.nn.functional.cross_entropy(t, torch.tensor(labels))
+ref_loss.backward()
+assert np.allclose(dlogits, t.grad.numpy(), atol=1e-8), 'dlogits does not match PyTorch autograd'
+""",
+        },
+        {
+            "name": "Gradient rows sum to zero",
+            "code": """
+import numpy as np
+np.random.seed(3)
+logits = np.random.randn(5, 4)
+labels = np.random.randint(0, 4, size=5)
+_, dlogits = {fn}(logits, labels)
+row_sums = dlogits.sum(axis=1)
+assert np.allclose(row_sums, 0, atol=1e-10), \\
+    f'Each row of (p - onehot)/N sums to 0 because probabilities sum to 1: {row_sums}'
+assert np.allclose(dlogits.sum(), 0, atol=1e-10), 'Total gradient must be 0'
+""",
+        },
+        {
+            "name": "Numerically stable on large logits",
+            "code": """
+import numpy as np
+logits = np.array([[1000.0, 1001.0, 999.0], [-1000.0, -1001.0, -999.0]])
+labels = np.array([1, 2])
+loss, dlogits = {fn}(logits, labels)
+assert np.isfinite(loss), f'Loss overflowed to {loss} — subtract the row max before exp'
+assert np.isfinite(dlogits).all(), 'Gradient overflowed — subtract the row max before exp'
+""",
+        },
+        {
+            "name": "Shift invariance",
+            "code": """
+import numpy as np
+np.random.seed(4)
+logits = np.random.randn(4, 3)
+labels = np.array([0, 1, 2, 1])
+loss_a, grad_a = {fn}(logits, labels)
+loss_b, grad_b = {fn}(logits + 7.0, labels)
+assert abs(float(loss_a) - float(loss_b)) < 1e-9, 'Softmax is shift-invariant — adding a constant must not change the loss'
+assert np.allclose(grad_a, grad_b, atol=1e-9), 'Gradient must be shift-invariant too'
+""",
+        },
+    ],
+}


### PR DESCRIPTION
…et category

Diffusion Training (+3):
- 37 flow_matching: rectified-flow velocity regression on the straight path x_t = (1-t)x0 + t*x1, target u = x1 - x0
- 38 dmd2: distribution matching loss — reverse-KL gradient as a score difference, per-sample normalizer, stopgrad surrogate for autograd
- 39 cfg: classifier-free guidance extrapolation plus the per-sample std-rescale trick

New category "NumPy 手写神经网络" (+6) — no autograd, no torch:
- 40 numpy_mlp_forward: affine + ReLU chain, linear logits
- 41 numpy_softmax_ce: stable softmax and the fused (p - onehot)/N gradient
- 42 numpy_mlp_backward: full L-layer backprop with forward caching
- 43 numpy_conv2d: cross-correlation forward with stride/padding
- 44 numpy_conv2d_backward: dx/dw/db with overlapping-window accumulation
- 45 numpy_maxpool2d: argmax routing, returns a backward closure

Each problem ships a template notebook (core idea, signature, rules, example) and a commented reference solution. All 62 new tests pass against the reference solutions via the same execution path as the web judge; the blank templates pass none of them.

Also: register the new category in _registry.py, update both READMEs (36 -> 45 problems).